### PR TITLE
SSRF via DCR Registration Endpoint in MissionSquad/mcp-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@missionsquad/mcp-api",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "description": "MCP Servers exposed via HTTP API",
   "main": "dist/index.js",
   "repository": "missionsquad/mcp-api",

--- a/src/services/dcrClients.ts
+++ b/src/services/dcrClients.ts
@@ -3,6 +3,7 @@ import { env } from '../env'
 import { log, sleep } from '../utils/general'
 import { IndexDefinition, MongoConnectionParams, MongoDBClient } from '../utils/mongodb'
 import { SecretEncryptor } from '../utils/secretEncryptor'
+import { validateExternalMcpUrl } from '../utils/ssrf'
 import { McpValidationError } from './mcpErrors'
 
 export type SupportedTokenEndpointAuthMethod = 'none' | 'client_secret_post' | 'client_secret_basic'
@@ -108,6 +109,19 @@ export const resolvePreferredTokenEndpointAuthMethod = (
   throw new McpValidationError(
     'Dynamic client registration requires one of these token endpoint auth methods: none, client_secret_post, client_secret_basic'
   )
+}
+
+export const assertSafeDcrRegistrationEndpoint = async (registrationEndpoint: string): Promise<void> => {
+  try {
+    await validateExternalMcpUrl(registrationEndpoint)
+  } catch (error) {
+    if (error instanceof McpValidationError) {
+      throw new McpValidationError(
+        `oauthTemplate.registrationEndpoint failed SSRF validation: ${error.message}`
+      )
+    }
+    throw error
+  }
 }
 
 const isClientSecretExpired = (record: McpDcrClientRegistrationRecord): boolean => {
@@ -250,6 +264,7 @@ export class McpDcrClients {
     tokenEndpointAuthMethodsSupported?: string[]
     oauthProvisioningContext: ExternalOAuthProvisioningContext
   }): Promise<McpDcrClientRegistrationRecord> {
+    await assertSafeDcrRegistrationEndpoint(input.registrationEndpoint)
     const tokenEndpointAuthMethod = resolvePreferredTokenEndpointAuthMethod(
       input.tokenEndpointAuthMethodsSupported
     )

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -23,6 +23,7 @@ import {
   ExternalOAuthProvisioningContext,
   McpDcrClients,
   SupportedTokenEndpointAuthMethod,
+  assertSafeDcrRegistrationEndpoint,
   normalizeTokenEndpointAuthMethods
 } from './dcrClients'
 import {
@@ -1949,6 +1950,11 @@ export class MCPService implements Resource {
     }
 
     this.validateExternalOAuthTemplate(authMode, normalizedTemplate, transportUrl)
+
+    if (normalizedTemplate.registrationEndpoint) {
+      await assertSafeDcrRegistrationEndpoint(normalizedTemplate.registrationEndpoint)
+    }
+
     return normalizedTemplate
   }
 

--- a/test/mcp-external-auth.spec.ts
+++ b/test/mcp-external-auth.spec.ts
@@ -24,7 +24,11 @@ import {
 } from '../src/services/mcpErrors'
 import { McpOAuthClientProvider, McpOAuthTokens } from '../src/services/oauthTokens'
 import { resolveInitialUserInstallAuthState } from '../src/services/userServerInstalls'
-import { McpDcrClients, resolvePreferredTokenEndpointAuthMethod } from '../src/services/dcrClients'
+import {
+  McpDcrClients,
+  assertSafeDcrRegistrationEndpoint,
+  resolvePreferredTokenEndpointAuthMethod
+} from '../src/services/dcrClients'
 import { validateExternalMcpUrl } from '../src/utils/ssrf'
 
 const originalFetch = global.fetch
@@ -218,6 +222,99 @@ describe('external MCP request validation', () => {
       process.env.EXTERNAL_MCP_PRIVATE_HOST_ALLOWLIST = previousAllowlist
     }
     lookupSpy.mockRestore()
+  })
+
+  test.each([
+    ['javascript:alert(1)'],
+    ['file:///etc/passwd'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['ftp://example.com/foo'],
+    ['gopher://example.com/_GET'],
+    ['ws://example.com/socket'],
+    ['wss://example.com/socket']
+  ])('validateExternalMcpUrl rejects non-http(s) scheme %s', async (urlString) => {
+    await expect(validateExternalMcpUrl(urlString)).rejects.toThrow(
+      'External MCP server url must use http or https'
+    )
+  })
+
+  test.each([
+    [''],
+    ['   '],
+    ['/relative/path'],
+    ['not-a-url'],
+    ['http://']
+  ])('validateExternalMcpUrl rejects malformed url %p', async (urlString) => {
+    await expect(validateExternalMcpUrl(urlString)).rejects.toThrow(
+      /must be a valid URL|hostname is required/
+    )
+  })
+
+  test.each([
+    ['javascript:alert(1)'],
+    ['file:///etc/passwd'],
+    ['data:text/html,evil'],
+    [''],
+    ['/relative/path']
+  ])('assertSafeDcrRegistrationEndpoint propagates rejection for unsafe input %p', async (urlString) => {
+    await expect(assertSafeDcrRegistrationEndpoint(urlString)).rejects.toThrow(
+      /oauthTemplate\.registrationEndpoint failed SSRF validation/
+    )
+  })
+
+  test('persistence normalization rejects non-http(s) DCR registrationEndpoint schemes', async () => {
+    const service = new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: {} as never,
+      userServerInstalls: {} as never
+    })
+
+    await expect(
+      (service as any).normalizeExternalOAuthTemplateForPersistence(
+        'oauth2',
+        'https://mcp.example.com/v1/mcp',
+        {
+          authorizationServerIssuer: 'https://auth.example.com',
+          authorizationServerMetadataUrl: 'https://auth.example.com/.well-known/oauth-authorization-server',
+          resourceUri: 'https://mcp.example.com/v1/mcp',
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          codeChallengeMethodsSupported: ['S256'],
+          pkceRequired: true,
+          discoveryMode: 'auto',
+          discoverySource: 'issuer_override',
+          registrationMode: 'dcr',
+          registrationEndpoint: 'file:///etc/passwd',
+          tokenEndpointAuthMethodsSupported: ['client_secret_basic']
+        }
+      )
+    ).rejects.toThrow(/oauthTemplate\.registrationEndpoint failed SSRF validation.*http or https/)
+  })
+
+  test('dcrClients.registerNewClient blocks non-http(s) registrationEndpoint schemes before issuing fetch', async () => {
+    const fetchSpy = jest.fn()
+    global.fetch = fetchSpy as unknown as typeof global.fetch
+
+    const dcrClients = new McpDcrClients({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' }
+    })
+
+    await expect(
+      (dcrClients as any).registerNewClient({
+        issuer: 'https://auth.example.com',
+        registrationEndpoint: 'javascript:fetch("http://attacker.example/")',
+        tokenEndpointAuthMethodsSupported: ['client_secret_basic'],
+        oauthProvisioningContext: {
+          publicApiOrigin: 'https://missionsquad.example',
+          redirectUri: 'https://missionsquad.example/callback',
+          clientMetadataUrl: '',
+          clientName: 'MissionSquad'
+        }
+      })
+    ).rejects.toThrow(/oauthTemplate\.registrationEndpoint failed SSRF validation.*http or https/)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    global.fetch = originalFetch
   })
 
   test('rejects reserved OAuth authorization request params on external OAuth templates', () => {

--- a/test/mcp-external-auth.spec.ts
+++ b/test/mcp-external-auth.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../src/services/mcpErrors'
 import { McpOAuthClientProvider, McpOAuthTokens } from '../src/services/oauthTokens'
 import { resolveInitialUserInstallAuthState } from '../src/services/userServerInstalls'
-import { resolvePreferredTokenEndpointAuthMethod } from '../src/services/dcrClients'
+import { McpDcrClients, resolvePreferredTokenEndpointAuthMethod } from '../src/services/dcrClients'
 import { validateExternalMcpUrl } from '../src/utils/ssrf'
 
 const originalFetch = global.fetch
@@ -282,6 +282,194 @@ describe('external MCP request validation', () => {
         { name: 'prompt', value: 'consent' }
       ]
     })
+  })
+
+  test('persistence normalization rejects DCR registrationEndpoint pointed at a loopback IP', async () => {
+    const service = new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: {} as never,
+      userServerInstalls: {} as never
+    })
+
+    await expect(
+      (service as any).normalizeExternalOAuthTemplateForPersistence(
+        'oauth2',
+        'https://mcp.example.com/v1/mcp',
+        {
+          authorizationServerIssuer: 'https://auth.example.com',
+          authorizationServerMetadataUrl: 'https://auth.example.com/.well-known/oauth-authorization-server',
+          resourceUri: 'https://mcp.example.com/v1/mcp',
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          codeChallengeMethodsSupported: ['S256'],
+          pkceRequired: true,
+          discoveryMode: 'auto',
+          discoverySource: 'issuer_override',
+          registrationMode: 'dcr',
+          registrationEndpoint: 'http://127.0.0.1:8080/register',
+          tokenEndpointAuthMethodsSupported: ['client_secret_basic']
+        }
+      )
+    ).rejects.toThrow(/registrationEndpoint.*127\.0\.0\.1|Blocked private or local IPv4 address: 127\.0\.0\.1/)
+  })
+
+  test('persistence normalization rejects DCR registrationEndpoint hostnames that resolve to private IPs', async () => {
+    const lookupSpy = jest.spyOn(dns, 'lookup').mockImplementation(async (hostname: string) => {
+      if (hostname === 'attacker.internal') {
+        return [{ address: '10.0.0.5', family: 4 }] as any
+      }
+      return [{ address: '93.184.216.34', family: 4 }] as any
+    })
+
+    const service = new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: {} as never,
+      userServerInstalls: {} as never
+    })
+
+    await expect(
+      (service as any).normalizeExternalOAuthTemplateForPersistence(
+        'oauth2',
+        'https://mcp.example.com/v1/mcp',
+        {
+          authorizationServerIssuer: 'https://auth.example.com',
+          authorizationServerMetadataUrl: 'https://auth.example.com/.well-known/oauth-authorization-server',
+          resourceUri: 'https://mcp.example.com/v1/mcp',
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          codeChallengeMethodsSupported: ['S256'],
+          pkceRequired: true,
+          discoveryMode: 'auto',
+          discoverySource: 'issuer_override',
+          registrationMode: 'dcr',
+          registrationEndpoint: 'https://attacker.internal/register',
+          tokenEndpointAuthMethodsSupported: ['client_secret_basic']
+        }
+      )
+    ).rejects.toThrow(/registrationEndpoint.*10\.0\.0\.5|Blocked private or local IPv4 address: 10\.0\.0\.5/)
+
+    lookupSpy.mockRestore()
+  })
+
+  test('persistence normalization rejects manual-mode templates that still set an unsafe registrationEndpoint', async () => {
+    const service = new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: {} as never,
+      userServerInstalls: {} as never
+    })
+
+    await expect(
+      (service as any).normalizeExternalOAuthTemplateForPersistence(
+        'oauth2',
+        'https://mcp.example.com/v1/mcp',
+        {
+          authorizationServerIssuer: '',
+          authorizationServerMetadataUrl: '',
+          resourceMetadataUrl: '',
+          resourceUri: 'https://mcp.example.com/v1/mcp',
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          codeChallengeMethodsSupported: ['S256'],
+          pkceRequired: true,
+          discoveryMode: 'manual',
+          registrationMode: 'manual',
+          registrationEndpoint: 'http://127.0.0.1/register'
+        }
+      )
+    ).rejects.toThrow(/registrationEndpoint.*127\.0\.0\.1|Blocked private or local IPv4 address: 127\.0\.0\.1/)
+  })
+
+  test('persistence normalization accepts public-resolved DCR registrationEndpoint', async () => {
+    const lookupSpy = jest.spyOn(dns, 'lookup').mockImplementation(async () =>
+      [{ address: '93.184.216.34', family: 4 }] as any
+    )
+
+    const service = new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: {} as never,
+      userServerInstalls: {} as never
+    })
+
+    await expect(
+      (service as any).normalizeExternalOAuthTemplateForPersistence(
+        'oauth2',
+        'https://mcp.example.com/v1/mcp',
+        {
+          authorizationServerIssuer: 'https://auth.example.com',
+          authorizationServerMetadataUrl: 'https://auth.example.com/.well-known/oauth-authorization-server',
+          resourceUri: 'https://mcp.example.com/v1/mcp',
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          codeChallengeMethodsSupported: ['S256'],
+          pkceRequired: true,
+          discoveryMode: 'auto',
+          discoverySource: 'issuer_override',
+          registrationMode: 'dcr',
+          registrationEndpoint: 'https://auth.example.com/register',
+          tokenEndpointAuthMethodsSupported: ['client_secret_basic']
+        }
+      )
+    ).resolves.toMatchObject({
+      registrationEndpoint: 'https://auth.example.com/register'
+    })
+
+    lookupSpy.mockRestore()
+  })
+
+  test('dcrClients.registerNewClient blocks loopback registration endpoints before issuing fetch', async () => {
+    const fetchSpy = jest.fn()
+    global.fetch = fetchSpy as unknown as typeof global.fetch
+
+    const dcrClients = new McpDcrClients({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' }
+    })
+
+    await expect(
+      (dcrClients as any).registerNewClient({
+        issuer: 'https://auth.example.com',
+        registrationEndpoint: 'http://127.0.0.1:8080/register',
+        tokenEndpointAuthMethodsSupported: ['client_secret_basic'],
+        oauthProvisioningContext: {
+          publicApiOrigin: 'https://missionsquad.example',
+          redirectUri: 'https://missionsquad.example/callback',
+          clientMetadataUrl: '',
+          clientName: 'MissionSquad'
+        }
+      })
+    ).rejects.toThrow(/Blocked private or local IPv4 address: 127\.0\.0\.1|registrationEndpoint/)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    global.fetch = originalFetch
+  })
+
+  test('dcrClients.registerNewClient blocks hostnames that resolve to private IPs before issuing fetch', async () => {
+    const lookupSpy = jest.spyOn(dns, 'lookup').mockImplementation(async () =>
+      [{ address: '169.254.169.254', family: 4 }] as any
+    )
+    const fetchSpy = jest.fn()
+    global.fetch = fetchSpy as unknown as typeof global.fetch
+
+    const dcrClients = new McpDcrClients({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' }
+    })
+
+    await expect(
+      (dcrClients as any).registerNewClient({
+        issuer: 'https://auth.example.com',
+        registrationEndpoint: 'http://metadata.internal/register',
+        tokenEndpointAuthMethodsSupported: ['client_secret_basic'],
+        oauthProvisioningContext: {
+          publicApiOrigin: 'https://missionsquad.example',
+          redirectUri: 'https://missionsquad.example/callback',
+          clientMetadataUrl: '',
+          clientName: 'MissionSquad'
+        }
+      })
+    ).rejects.toThrow(/Blocked private or local IPv4 address: 169\.254\.169\.254|registrationEndpoint/)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    lookupSpy.mockRestore()
+    global.fetch = originalFetch
   })
 })
 


### PR DESCRIPTION
Closes #42

## What changed

The OAuth Dynamic Client Registration (DCR) flow accepted a caller-controlled
`oauthTemplate.registrationEndpoint` URL and later issued a server-side `POST`
to it via `fetch()`. The external MCP transport URL was already validated with
`validateExternalMcpUrl()`, but the `registrationEndpoint` was not, so a caller
who could add (or have a server resolve) a DCR-backed external OAuth template
could coerce `mcp-api` into POSTing the DCR registration payload at internal or
loopback addresses such as `http://127.0.0.1:<port>`.

The fix runs the same SSRF protections on `registrationEndpoint` in the two
places where unsafe values could otherwise reach `fetch`:

- **Persistence path** — `MCPService.normalizeExternalOAuthTemplateForPersistence`
  (used by `addServer` and `updateServer`) now calls
  `assertSafeDcrRegistrationEndpoint(registrationEndpoint)` before returning
  the normalized template. Loopback, private, link-local, and other unsafe
  destinations are rejected with `McpValidationError` before they are stored.
- **Fetch path** — `McpDcrClients.registerNewClient` re-runs the same check
  immediately before `fetch(input.registrationEndpoint, ...)`. This is
  defense-in-depth for paths that re-use a stored endpoint (e.g. the
  `invalid_client` re-registration path in `oauthTokens.ts`).

A shared helper `assertSafeDcrRegistrationEndpoint` (exported from
`src/services/dcrClients.ts`) wraps `validateExternalMcpUrl` and tags the
failure message with the offending field so the error is clearly attributable.

## How to test

Run the test suite (six new cases were added to `test/mcp-external-auth.spec.ts`):

```
yarn install
yarn test
```

The new cases cover:

- Persistence normalization rejects a DCR `registrationEndpoint` pointed at a literal loopback IP.
- Persistence normalization rejects a DCR `registrationEndpoint` whose hostname resolves (via DNS) to a private IPv4 address.
- Persistence normalization rejects even a manual-mode template that still carries an unsafe `registrationEndpoint` (defense-in-depth).
- Persistence normalization accepts a public-resolved DCR `registrationEndpoint`.
- `McpDcrClients.registerNewClient` blocks loopback URLs and never invokes `fetch`.
- `McpDcrClients.registerNewClient` blocks hostnames resolving to private IPs (e.g. `169.254.169.254`) and never invokes `fetch`.

Manual reproduction of the original PoC — calling `MCPService.addServer(...)` with
`oauthTemplate.registrationEndpoint = http://127.0.0.1:<port>/dcr-poc` — now
fails fast with `oauthTemplate.registrationEndpoint failed SSRF validation:
Blocked private or local IPv4 address: 127.0.0.1`, and the local listener never
receives a POST.