### PR TITLE
Periodic resource-stats logging for mcp-api and spawned MCP servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@missionsquad/mcp-api",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "MCP Servers exposed via HTTP API",
   "main": "dist/index.js",
   "repository": "missionsquad/mcp-api",

--- a/src/env.ts
+++ b/src/env.ts
@@ -19,6 +19,7 @@ export const env = {
     return { repo, name }
   }),
   SEARXNG_URL: process.env.SEARXNG_URL,
+  RESOURCE_STATS_INTERVAL_MS: Number(process.env.RESOURCE_STATS_INTERVAL_MS ?? 60000) || 0,
   PYTHON_BIN: process.env.PYTHON_BIN,
   PYTHON_VENV_DIR: process.env.PYTHON_VENV_DIR || 'packages/python',
   PIP_INDEX_URL: process.env.PIP_INDEX_URL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { McpOAuthTokens } from './services/oauthTokens'
 import { McpUserSessions } from './services/userSessions'
 import { McpUserServerInstalls } from './services/userServerInstalls'
 import { McpDcrClients } from './services/dcrClients'
+import { ResourceStatsService } from './services/resourceStats'
 
 export type Resource = {
   init: () => Promise<void>
@@ -92,6 +93,14 @@ export class API {
     
     // Set up circular dependency between MCPService and PackageService
     mcpController.getMcpService().setPackageService(packagesController.getPackageService())
+
+    // Periodic resource-stats logging for mcp-api and its spawned MCP servers
+    const resourceStatsService = new ResourceStatsService({
+      intervalMs: env.RESOURCE_STATS_INTERVAL_MS,
+      getTrackedProcesses: () => mcpController.getMcpService().getStdioServerPids()
+    })
+    await resourceStatsService.init()
+    this.resources.push(resourceStatsService)
 
     app.get('/healthz', (req, res) => {
       console.log('Health checked')

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -42,6 +42,7 @@ import {
   McpServerAlreadyExistsError
 } from './mcpErrors'
 import { validateExternalMcpUrl } from '../utils/ssrf'
+import { getStdioTransportPid } from '../utils/resourceStats'
 
 export interface MCPConnection {
   client: Client
@@ -3814,6 +3815,25 @@ export class MCPService implements Resource {
     }
 
     return updatedServer
+  }
+
+  /**
+   * Lists the OS process ids of currently running stdio MCP servers,
+   * labeled by server name, for resource monitoring.
+   */
+  public getStdioServerPids(): { name: string; pid: number }[] {
+    const tracked: { name: string; pid: number }[] = []
+    for (const serverKey of Object.keys(this.servers)) {
+      const server = this.servers[serverKey]
+      if (server.transportType !== 'stdio') continue
+      const transport = server.connection?.transport
+      if (!transport) continue
+      const pid = getStdioTransportPid(transport)
+      if (pid !== undefined) {
+        tracked.push({ name: server.name, pid })
+      }
+    }
+    return tracked
   }
 
   public async stop() {

--- a/src/services/resourceStats.ts
+++ b/src/services/resourceStats.ts
@@ -1,0 +1,126 @@
+import { Resource } from '..'
+import { log } from '../utils/general'
+import {
+  SubtreeSample,
+  aggregateDirectChildSubtrees,
+  formatMebibytes,
+  sampleProcessTree
+} from '../utils/resourceStats'
+
+export interface TrackedProcess {
+  name: string
+  pid: number
+}
+
+export interface ResourceStatsServiceOptions {
+  /** Sampling interval in milliseconds. Values <= 0 disable sampling entirely. */
+  intervalMs: number
+  /** Returns the currently running MCP server child processes to label by name. */
+  getTrackedProcesses: () => TrackedProcess[]
+}
+
+/**
+ * Periodically logs memory/CPU usage for the mcp-api process itself, every
+ * child process subtree it has spawned (installed stdio MCP servers, the
+ * Puppeteer-managed browser, package installs, ...), and a machine-facing
+ * total, so resource consumption is visible in the service logs over time.
+ */
+export class ResourceStatsService implements Resource {
+  private readonly intervalMs: number
+  private readonly getTrackedProcesses: () => TrackedProcess[]
+  private timer?: NodeJS.Timeout
+  private lastCpuUsage = process.cpuUsage()
+  private lastCpuSampleAt = process.hrtime.bigint()
+  private treeSamplingBroken = false
+
+  constructor({ intervalMs, getTrackedProcesses }: ResourceStatsServiceOptions) {
+    this.intervalMs = intervalMs
+    this.getTrackedProcesses = getTrackedProcesses
+  }
+
+  public async init(): Promise<void> {
+    if (!Number.isFinite(this.intervalMs) || this.intervalMs <= 0) {
+      log({ level: 'info', msg: '[resource-stats] disabled (RESOURCE_STATS_INTERVAL_MS <= 0)' })
+      return
+    }
+    this.lastCpuUsage = process.cpuUsage()
+    this.lastCpuSampleAt = process.hrtime.bigint()
+    this.timer = setInterval(() => {
+      this.logSample().catch((error) => {
+        log({ level: 'debug', msg: '[resource-stats] sampling failed', error })
+      })
+    }, this.intervalMs)
+    // Never keep the process alive just to report stats
+    this.timer.unref()
+    log({ level: 'info', msg: `[resource-stats] sampling every ${this.intervalMs}ms` })
+  }
+
+  public async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = undefined
+    }
+  }
+
+  private sampleSelfCpuPercent(): number {
+    const now = process.hrtime.bigint()
+    const elapsedMicros = Number(now - this.lastCpuSampleAt) / 1000
+    const usage = process.cpuUsage(this.lastCpuUsage)
+    this.lastCpuUsage = process.cpuUsage()
+    this.lastCpuSampleAt = now
+    if (elapsedMicros <= 0) {
+      return 0
+    }
+    return ((usage.user + usage.system) / elapsedMicros) * 100
+  }
+
+  private async logSample(): Promise<void> {
+    const memory = process.memoryUsage()
+    const cpuPercent = this.sampleSelfCpuPercent()
+    log({
+      level: 'info',
+      msg:
+        `[resource-stats] self pid=${process.pid} rss=${formatMebibytes(memory.rss)} ` +
+        `heapUsed=${formatMebibytes(memory.heapUsed)} heapTotal=${formatMebibytes(memory.heapTotal)} ` +
+        `external=${formatMebibytes(memory.external)} cpu=${cpuPercent.toFixed(1)}%`
+    })
+
+    let subtrees: SubtreeSample[]
+    try {
+      const tree = await sampleProcessTree()
+      subtrees = aggregateDirectChildSubtrees(tree, process.pid)
+      this.treeSamplingBroken = false
+    } catch (error) {
+      // Warn once, then stay quiet: without `ps` only self stats are available
+      if (!this.treeSamplingBroken) {
+        this.treeSamplingBroken = true
+        log({ level: 'warn', msg: '[resource-stats] cannot sample child processes (is `ps` available?)', error })
+      }
+      return
+    }
+
+    const nameByPid = new Map<number, string>()
+    for (const tracked of this.getTrackedProcesses()) {
+      nameByPid.set(tracked.pid, tracked.name)
+    }
+
+    for (const subtree of subtrees) {
+      const name = nameByPid.get(subtree.rootPid) ?? subtree.command
+      log({
+        level: 'info',
+        msg:
+          `[resource-stats] child name=${name} pid=${subtree.rootPid} ` +
+          `rss=${formatMebibytes(subtree.rssBytes)} cpu=${subtree.cpuPercent.toFixed(1)}% procs=${subtree.processCount}`
+      })
+    }
+
+    const childRss = subtrees.reduce((sum, subtree) => sum + subtree.rssBytes, 0)
+    const childProcs = subtrees.reduce((sum, subtree) => sum + subtree.processCount, 0)
+    log({
+      level: 'info',
+      msg:
+        `[resource-stats] total rss=${formatMebibytes(memory.rss + childRss)} ` +
+        `procs=${childProcs + 1} (self + ${childProcs} descendants)`
+    })
+  }
+}

--- a/src/utils/resourceStats.ts
+++ b/src/utils/resourceStats.ts
@@ -1,0 +1,123 @@
+import { execFile } from 'node:child_process'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+
+export interface ProcessSample {
+  pid: number
+  ppid: number
+  rssBytes: number
+  cpuPercent: number
+  command: string
+}
+
+export interface SubtreeSample {
+  rootPid: number
+  command: string
+  rssBytes: number
+  cpuPercent: number
+  processCount: number
+}
+
+/**
+ * Extracts the OS process id from a stdio client transport.
+ *
+ * @modelcontextprotocol/sdk 1.13.0 does not expose a public accessor for the
+ * spawned child process (verified against dist/cjs/client/stdio.d.ts: `_process`
+ * is private and no `pid` getter exists). This helper is the single, isolated
+ * place that reaches into that private field, and it validates the value at
+ * runtime so an SDK upgrade that changes internals degrades to `undefined`
+ * instead of misbehaving.
+ */
+export function getStdioTransportPid(transport: Transport): number | undefined {
+  if (!(transport instanceof StdioClientTransport)) {
+    return undefined
+  }
+  const internals = transport as unknown as { _process?: { pid?: unknown } }
+  const pid = internals._process?.pid
+  return typeof pid === 'number' && Number.isInteger(pid) && pid > 0 ? pid : undefined
+}
+
+/**
+ * Parses `ps -eo pid=,ppid=,rss=,pcpu=,comm=` output.
+ * rss is reported by ps in kilobytes on both Linux (procps) and macOS (BSD ps).
+ * The command field may contain spaces, so it is everything after the fourth column.
+ */
+export function parsePsOutput(output: string): ProcessSample[] {
+  const samples: ProcessSample[] = []
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(\d+)\s+([\d.]+)\s+(.+)$/)
+    if (!match) continue
+    samples.push({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      rssBytes: Number(match[3]) * 1024,
+      cpuPercent: Number(match[4]),
+      command: match[5].trim()
+    })
+  }
+  return samples
+}
+
+/**
+ * Groups every process descending from rootPid into one aggregate per direct
+ * child of rootPid: the child's own usage plus everything below it. This keeps
+ * one log line per spawned server (or browser) even when it forks helpers of
+ * its own (e.g. Chromium renderer processes).
+ */
+export function aggregateDirectChildSubtrees(samples: ProcessSample[], rootPid: number): SubtreeSample[] {
+  const childrenByPpid = new Map<number, ProcessSample[]>()
+  for (const sample of samples) {
+    const siblings = childrenByPpid.get(sample.ppid)
+    if (siblings) {
+      siblings.push(sample)
+    } else {
+      childrenByPpid.set(sample.ppid, [sample])
+    }
+  }
+
+  const collectSubtree = (pid: number, into: ProcessSample[], seen: Set<number>): void => {
+    for (const child of childrenByPpid.get(pid) ?? []) {
+      if (seen.has(child.pid)) continue
+      seen.add(child.pid)
+      into.push(child)
+      collectSubtree(child.pid, into, seen)
+    }
+  }
+
+  const subtrees: SubtreeSample[] = []
+  for (const directChild of childrenByPpid.get(rootPid) ?? []) {
+    const members: ProcessSample[] = [directChild]
+    collectSubtree(directChild.pid, members, new Set([directChild.pid]))
+    subtrees.push({
+      rootPid: directChild.pid,
+      command: directChild.command,
+      rssBytes: members.reduce((sum, m) => sum + m.rssBytes, 0),
+      cpuPercent: members.reduce((sum, m) => sum + m.cpuPercent, 0),
+      processCount: members.length
+    })
+  }
+  return subtrees
+}
+
+/**
+ * Samples the full OS process tree with a single `ps` invocation.
+ *
+ * @throws Error when `ps` is unavailable or exits abnormally.
+ */
+export function sampleProcessTree(): Promise<ProcessSample[]> {
+  return new Promise((resolve, reject) => {
+    execFile('ps', ['-eo', 'pid=,ppid=,rss=,pcpu=,comm='], { maxBuffer: 4 * 1024 * 1024 }, (error, stdout) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(parsePsOutput(stdout))
+    })
+  })
+}
+
+export function formatMebibytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}

--- a/test/resource-stats.spec.ts
+++ b/test/resource-stats.spec.ts
@@ -1,0 +1,124 @@
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import {
+  aggregateDirectChildSubtrees,
+  formatMebibytes,
+  getStdioTransportPid,
+  parsePsOutput,
+  sampleProcessTree
+} from '../src/utils/resourceStats'
+
+describe('parsePsOutput', () => {
+  it('parses pid, ppid, rss (KB -> bytes), pcpu and command', () => {
+    const output = [
+      '    1     0  1024  0.5 node',
+      ' 4321     1 20480 12.3 /usr/local/bin/node dist/index.js',
+      ''
+    ].join('\n')
+
+    const samples = parsePsOutput(output)
+    expect(samples).toEqual([
+      { pid: 1, ppid: 0, rssBytes: 1024 * 1024, cpuPercent: 0.5, command: 'node' },
+      { pid: 4321, ppid: 1, rssBytes: 20480 * 1024, cpuPercent: 12.3, command: '/usr/local/bin/node dist/index.js' }
+    ])
+  })
+
+  it('preserves spaces inside the command column', () => {
+    const samples = parsePsOutput('99 1 512 0.0 Google Chrome Helper (Renderer)')
+    expect(samples).toHaveLength(1)
+    expect(samples[0].command).toBe('Google Chrome Helper (Renderer)')
+  })
+
+  it('skips malformed lines', () => {
+    const samples = parsePsOutput('not a process line\n\n12 abc 100 0.0 zsh')
+    expect(samples).toEqual([])
+  })
+})
+
+describe('aggregateDirectChildSubtrees', () => {
+  const sample = (pid: number, ppid: number, rssKb: number, cpu: number, command: string) => ({
+    pid,
+    ppid,
+    rssBytes: rssKb * 1024,
+    cpuPercent: cpu,
+    command
+  })
+
+  it('aggregates each direct child with all of its descendants', () => {
+    const root = 100
+    const tree = [
+      sample(root, 1, 400_000, 2.0, 'node dist/index.js'), // self (excluded from subtrees)
+      sample(200, root, 50_000, 0.5, 'node mcp-github'), // stdio server
+      sample(300, root, 300_000, 3.0, 'chrome'), // browser
+      sample(301, 300, 150_000, 1.5, 'chrome'), // renderer under browser
+      sample(302, 301, 10_000, 0.1, 'chrome'), // nested helper
+      sample(999, 1, 999_000, 9.9, 'unrelated') // not in our tree
+    ]
+
+    const subtrees = aggregateDirectChildSubtrees(tree, root)
+    expect(subtrees).toHaveLength(2)
+
+    const server = subtrees.find((s) => s.rootPid === 200)
+    expect(server).toEqual({
+      rootPid: 200,
+      command: 'node mcp-github',
+      rssBytes: 50_000 * 1024,
+      cpuPercent: 0.5,
+      processCount: 1
+    })
+
+    const browser = subtrees.find((s) => s.rootPid === 300)
+    expect(browser).toBeDefined()
+    expect(browser!.rssBytes).toBe((300_000 + 150_000 + 10_000) * 1024)
+    expect(browser!.cpuPercent).toBeCloseTo(4.6)
+    expect(browser!.processCount).toBe(3)
+  })
+
+  it('returns an empty list when the root has no children', () => {
+    expect(aggregateDirectChildSubtrees([], 100)).toEqual([])
+  })
+
+  it('does not loop forever on cyclic ppid data', () => {
+    const tree = [sample(200, 100, 1, 0, 'a'), sample(201, 200, 1, 0, 'b'), sample(200, 201, 1, 0, 'a-again')]
+    const subtrees = aggregateDirectChildSubtrees(tree, 100)
+    expect(subtrees).toHaveLength(1)
+  })
+})
+
+describe('getStdioTransportPid', () => {
+  it('returns undefined for a transport that has not been started', () => {
+    const transport = new StdioClientTransport({ command: 'true' })
+    expect(getStdioTransportPid(transport)).toBeUndefined()
+  })
+
+  it('returns the pid of a started transport process', () => {
+    const transport = Object.create(StdioClientTransport.prototype) as StdioClientTransport
+    ;(transport as unknown as { _process: { pid: number } })._process = { pid: 4321 }
+    expect(getStdioTransportPid(transport)).toBe(4321)
+  })
+
+  it('rejects non-numeric pid values', () => {
+    const transport = Object.create(StdioClientTransport.prototype) as StdioClientTransport
+    ;(transport as unknown as { _process: { pid: unknown } })._process = { pid: 'nope' }
+    expect(getStdioTransportPid(transport)).toBeUndefined()
+  })
+
+  it('returns undefined for non-stdio transports', () => {
+    const fake = { start: async () => undefined, send: async () => undefined, close: async () => undefined }
+    expect(getStdioTransportPid(fake)).toBeUndefined()
+  })
+})
+
+describe('sampleProcessTree', () => {
+  it('samples the live process tree and includes this process', async () => {
+    const samples = await sampleProcessTree()
+    expect(samples.length).toBeGreaterThan(0)
+    expect(samples.some((s) => s.pid === process.pid)).toBe(true)
+  })
+})
+
+describe('formatMebibytes', () => {
+  it('formats bytes as MB with one decimal', () => {
+    expect(formatMebibytes(412.3 * 1024 * 1024)).toBe('412.3MB')
+    expect(formatMebibytes(0)).toBe('0.0MB')
+  })
+})


### PR DESCRIPTION
## Summary
- Logs a resource snapshot to the mcp-api logs every `RESOURCE_STATS_INTERVAL_MS` (default 60000; set `0` to disable)
- One line for mcp-api itself (`rss`, `heapUsed`, `heapTotal`, `external`, `cpu%`), one aggregated line per child process subtree, and a machine-facing total
- Installed stdio MCP servers are labeled by server name (pid read via a single isolated, runtime-validated accessor — SDK 1.13.0 exposes no public pid on `StdioClientTransport`); other children (e.g. the Puppeteer Chromium tree, including renderers) are labeled by command and rolled up per subtree
- Sampling is one `ps` invocation per tick; works on the `node:20` Debian image and macOS. If `ps` is unavailable it warns once and keeps logging self stats

Example output:
```
[INFO] [resource-stats] self pid=812 rss=412.3MB heapUsed=180.1MB heapTotal=220.0MB external=35.2MB cpu=2.1%
[INFO] [resource-stats] child name=github pid=1234 rss=88.2MB cpu=0.3% procs=1
[INFO] [resource-stats] child name=chrome pid=2222 rss=612.9MB cpu=4.0% procs=7
[INFO] [resource-stats] total rss=1113.4MB procs=9 (self + 8 descendants)
```

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full jest suite: 86/86 passing (includes new `test/resource-stats.spec.ts` covering the ps parser, subtree aggregation incl. cycle safety, the pid accessor guard, and a live process-tree sample)

🤖 Generated with [Claude Code](https://claude.com/claude-code)