### PR TITLE
fix: cap in-memory MCP server logs at 500 lines; close Chromium on webtools stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@missionsquad/mcp-api",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "MCP Servers exposed via HTTP API",
   "main": "dist/index.js",
   "repository": "missionsquad/mcp-api",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Jayson Jacobs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@missionsquad/puppeteer-scraper": "^1.1.1",
+    "@missionsquad/puppeteer-scraper": "^1.1.2",
     "@modelcontextprotocol/sdk": "^1.13.0",
     "@types/bcrypt": "^5.0.2",
     "base64-js": "^1.5.1",

--- a/src/builtin-servers/servers/searxng.ts
+++ b/src/builtin-servers/servers/searxng.ts
@@ -99,12 +99,13 @@ export class BuiltInSearxngServer extends BaseBuiltInServer {
   async stop(): Promise<void> {
     if (this.scraper) {
       try {
-        // Puppeteer cleanup would go here
-        // Note: PuppeteerScraper needs a cleanup method
+        await this.scraper.closeBrowser()
         log({ level: 'info', msg: 'Stopped Puppeteer scraper' })
       } catch (error) {
         log({ level: 'error', msg: 'Error stopping Puppeteer scraper', error })
       }
+      this.scraper = null
+      this.scraperReady = false
     }
   }
   

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -917,6 +917,29 @@ const normalizeExternalAuthError = (
   return error
 }
 
+/**
+ * Maximum number of in-memory log lines retained per MCP server and per
+ * per-user connection. Older lines are displaced once this count is exceeded.
+ */
+export const MAX_SERVER_LOG_LINES = 500
+
+/**
+ * Append a log line to an in-memory logs array, capping the array at
+ * {@link MAX_SERVER_LOG_LINES} entries by COUNT ONLY (no time-based eviction).
+ * When the cap is exceeded, the oldest lines are dropped so the array retains
+ * the most recent {@link MAX_SERVER_LOG_LINES} lines in insertion order.
+ *
+ * @param logs - The logs array to append to. A no-op when `undefined`.
+ * @param message - The log line to append.
+ */
+export function appendServerLog(logs: string[] | undefined, message: string): void {
+  if (!logs) return
+  logs.push(message)
+  if (logs.length > MAX_SERVER_LOG_LINES) {
+    logs.splice(0, logs.length - MAX_SERVER_LOG_LINES)
+  }
+}
+
 export class MCPService implements Resource {
   public servers: Record<string, MCPServer> = {}
   public userConnections: Record<UserServerKey, UserConnection> = {}
@@ -2248,7 +2271,7 @@ export class MCPService implements Resource {
     const transportErrorHandler = async (error: Error) => {
       log({ level: 'error', msg: `${serverKey} transport error: ${error.message}`, error })
       if (this.servers[serverKey]) {
-        this.servers[serverKey].logs?.push(error.message)
+        appendServerLog(this.servers[serverKey].logs, error.message)
       }
     }
 
@@ -2320,7 +2343,7 @@ export class MCPService implements Resource {
             const logMsg = data.toString().trim()
             log({ level: 'error', msg: `[${server.name}] stderr: ${logMsg}` })
             if (this.servers[serverKey]) {
-              this.servers[serverKey].logs?.push(logMsg)
+              appendServerLog(this.servers[serverKey].logs, logMsg)
             }
           }
 
@@ -2446,7 +2469,7 @@ export class MCPService implements Resource {
       log({ level: 'error', msg: `[${username}:${server.name}] transport error: ${error.message}`, error })
       const conn = this.userConnections[userKey]
       if (conn) {
-        conn.logs?.push(error.message)
+        appendServerLog(conn.logs, error.message)
       }
     }
 

--- a/test/server-logs-cap.spec.ts
+++ b/test/server-logs-cap.spec.ts
@@ -1,0 +1,63 @@
+import { appendServerLog, MAX_SERVER_LOG_LINES } from '../src/services/mcp'
+
+describe('appendServerLog', () => {
+  it('exposes a cap of 500 lines', () => {
+    expect(MAX_SERVER_LOG_LINES).toBe(500)
+  })
+
+  it('appends normally when under the cap', () => {
+    const logs: string[] = []
+    appendServerLog(logs, 'a')
+    appendServerLog(logs, 'b')
+    appendServerLog(logs, 'c')
+    expect(logs).toEqual(['a', 'b', 'c'])
+    expect(logs.length).toBe(3)
+  })
+
+  it('keeps exactly the last 500 entries in order once the cap is exceeded (oldest dropped)', () => {
+    const logs: string[] = []
+    const total = MAX_SERVER_LOG_LINES + 250 // 750 entries pushed
+    for (let i = 0; i < total; i++) {
+      appendServerLog(logs, `line-${i}`)
+    }
+    expect(logs.length).toBe(MAX_SERVER_LOG_LINES)
+    // The oldest 250 (line-0 .. line-249) must have been dropped.
+    expect(logs[0]).toBe(`line-${total - MAX_SERVER_LOG_LINES}`) // line-250
+    expect(logs[logs.length - 1]).toBe(`line-${total - 1}`) // line-749
+    // Contents are the last 500 lines in insertion order.
+    const expected: string[] = []
+    for (let i = total - MAX_SERVER_LOG_LINES; i < total; i++) {
+      expected.push(`line-${i}`)
+    }
+    expect(logs).toEqual(expected)
+  })
+
+  it('tolerates an undefined logs array without throwing', () => {
+    expect(() => appendServerLog(undefined, 'ignored')).not.toThrow()
+  })
+
+  it('maintains a steady-state length of 500 when called repeatedly one-at-a-time past the cap', () => {
+    const logs: string[] = []
+    // Fill exactly to the cap.
+    for (let i = 0; i < MAX_SERVER_LOG_LINES; i++) {
+      appendServerLog(logs, `seed-${i}`)
+    }
+    expect(logs.length).toBe(MAX_SERVER_LOG_LINES)
+
+    // Each subsequent single append must keep the length pinned at the cap,
+    // dropping exactly one oldest line and retaining the newest.
+    for (let i = 0; i < 1000; i++) {
+      appendServerLog(logs, `stream-${i}`)
+      expect(logs.length).toBe(MAX_SERVER_LOG_LINES)
+      expect(logs[logs.length - 1]).toBe(`stream-${i}`)
+    }
+
+    // After 1000 single appends past a full buffer, every seed line is gone
+    // and only the last 500 streamed lines remain, in order.
+    const expected: string[] = []
+    for (let i = 1000 - MAX_SERVER_LOG_LINES; i < 1000; i++) {
+      expected.push(`stream-${i}`)
+    }
+    expect(logs).toEqual(expected)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,10 +1195,10 @@
   dependencies:
     nanoid "3.3.10"
 
-"@missionsquad/puppeteer-scraper@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@missionsquad/puppeteer-scraper/-/puppeteer-scraper-1.1.1.tgz#55165637a4530c22a28dc1112c6509257ec47f10"
-  integrity sha512-IfmqCt65ucxvZmHKkeUo61EhZE+3n6nt4ZTTZ0OsxemEdOmWNcio4cq5pvOinDHXYackA2Z7BLogChiFBOMPYA==
+"@missionsquad/puppeteer-scraper@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@missionsquad/puppeteer-scraper/-/puppeteer-scraper-1.1.2.tgz#8569a5cade6715b5d4369df898975b8ebdec65d9"
+  integrity sha512-EUXDT3S5p+SIVEOqSGlF8zivNH2BsxagrExYamSeS9/e0NNKYCglizhSll+q+Pqn5LAj4ZK2goPDVKgMqQ7SGg==
   dependencies:
     "@missionsquad/common" "^1.1.0"
     browsers "^1.0.2"


### PR DESCRIPTION
## Summary

`MCPService` kept an in-memory `logs: string[]` for each shared MCP server and for each per-user connection, and appended to it on **every** child-process stderr line and **every** transport error — with no cap anywhere. Installed servers such as `mcp-msq` emit two or more stderr lines per tool call, so these arrays grew for the entire life of the process: an unbounded memory leak.

This PR:

- Adds a module-scoped helper `appendServerLog(logs, message)` and `MAX_SERVER_LOG_LINES = 500` in `src/services/mcp.ts`. It pushes the line and, once the array exceeds the cap, splices off the oldest entries so only the most recent 500 lines remain.
- The cap is **by count only** (per the user requirement): there is **no** time-based / TTL eviction. Logs may be read days later and must survive until displaced by newer lines.
- Routes all three push sites through the helper: the shared-server transport-error handler, the stdio stderr handler, and the per-user-connection transport-error handler. No uncapped `logs?.push(` remains.
- Fixes `BuiltInSearxngServer.stop()` (`src/builtin-servers/servers/searxng.ts`), which was a no-op containing only comments and never released the Puppeteer-managed Chromium browser on shutdown. It now `await`s `scraper.closeBrowser()` inside the existing try/catch and clears the scraper reference and ready flag.
- Bumps the package version from `1.11.8` to `1.11.9`.

Notes:

- The primary Chromium-tab leak is fixed separately in `MissionSquad/puppeteer-scraper`; this PR's `stop()` change ensures the browser is also closed on webtools shutdown.
- Resource-stats logging is tracked separately in PR #47.

## Test plan

- [x] `tsc -p tsconfig.json --noEmit` — clean, no errors.
- [x] Full jest suite green: **6 suites passed, 79 tests passed** (5 pre-existing suites + the new `test/server-logs-cap.spec.ts`).
- [x] New unit tests cover: normal append under the cap; exactly the last 500 kept in order once the cap is exceeded (oldest dropped); `undefined` logs tolerated without throwing; steady-state length pinned at 500 under repeated one-at-a-time appends past the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
