### PR TITLE
Add Comms Agent service-HMAC MCP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ The system uses AES-256-GCM encryption for all stored secrets, with a separate e
    PIP_EXTRA_INDEX_URL=
    ```
 
+   The optional Comms Management service-HMAC profile uses one additional environment variable:
+
+   ```text
+   MSQ_COMMS_MCP_HMAC_KEY_FILE=/absolute/path/to/a/mounted/keyring.json
+   ```
+
+   This value is an absolute secret-file path, not key material. The file must be a regular, non-symlink JSON file with mode `0400` or `0440` and the closed `SymmetricKeyring` shape used by the Comms Agent deployment contract. Do not reuse `SECRETS_KEY`, a user secret, an OAuth token, or another Mission Squad service keyring.
+
 5. Build the project:
 
    ```bash
@@ -115,6 +123,27 @@ docker run -p 8080:8080 --env-file .env mcp-api
 For Python MCP servers that require Python 3.13+ (for example `klaviyo-mcp-server`), do not override `PYTHON_BIN` to an older interpreter in container deployments.
 
 ## API Reference
+
+### Comms Management service-HMAC profile
+
+The V1 service-HMAC transport is limited to one platform-owned Streamable HTTP profile. Register it through the existing server-management API with these non-secret fields (the `name` remains the caller's stable platform server identifier):
+
+```json
+{
+  "name": "comms-management",
+  "source": "platform",
+  "transportType": "streamable_http",
+  "authMode": "service_hmac",
+  "serviceHmacProfile": "comms_management",
+  "url": "https://comms-management:8080/internal/mcp"
+}
+```
+
+The combination is closed. It cannot be selected by an external or user-installed server, stdio transport, another URL/profile, configured query or fragment, static headers, shared session ID, OAuth configuration, or external secret fields. Server responses may include the non-secret `serviceHmacProfile`; they never include the key-file path, key bytes, per-request authentication headers, timestamp, nonce, or signature.
+
+If the environment variable is absent, the keyring is invalid/out of its active window, or a reload fails validation, only this profile is unavailable. Its connection attempt returns a typed service-unavailable error and it does not claim a connected state; `/healthz` and all unrelated stdio, unauthenticated HTTP, and OAuth servers remain operational.
+
+Send `SIGHUP` after atomically replacing the mounted keyring file. A completely valid candidate becomes active for the next outbound request. An invalid candidate leaves the prior ring in memory only for later recovery but disables signing until a subsequent valid reload.
 
 ### Package Management
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@missionsquad/mcp-api",
-  "version": "1.11.19",
+  "version": "1.11.20",
   "description": "MCP Servers exposed via HTTP API",
   "main": "dist/index.js",
   "repository": "missionsquad/mcp-api",
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@missionsquad/puppeteer-scraper": "^1.1.2",
-    "@modelcontextprotocol/sdk": "^1.13.0",
+    "@modelcontextprotocol/sdk": "1.16.0",
     "@types/bcrypt": "^5.0.2",
     "base64-js": "^1.5.1",
     "base64-url": "^2.3.3",

--- a/src/controllers/mcp.ts
+++ b/src/controllers/mcp.ts
@@ -16,6 +16,7 @@ import type { McpUserSessions } from '../services/userSessions'
 import type { InstallUserServerInput, UpdateUserServerInstallInput, McpUserServerInstalls } from '../services/userServerInstalls'
 import { McpValidationError, toMcpErrorResponse } from '../services/mcpErrors'
 import type { ExternalOAuthProvisioningContext } from '../services/dcrClients'
+import type { ServiceHmacProvider } from '../services/serviceHmac'
 
 export interface ToolCallRequest {
   username: string
@@ -66,7 +67,8 @@ export class MCPController implements Resource {
     oauthTokensService,
     userSessionsService,
     userServerInstalls,
-    dcrClients
+    dcrClients,
+    serviceHmacProvider
   }: {
     app: Express
     mongoParams: MongoConnectionParams
@@ -75,6 +77,7 @@ export class MCPController implements Resource {
     userSessionsService?: McpUserSessions
     userServerInstalls: McpUserServerInstalls
     dcrClients?: import('../services/dcrClients').McpDcrClients
+    serviceHmacProvider: ServiceHmacProvider
   }) {
     this.app = app
     this.mcpService = new MCPService({
@@ -83,7 +86,8 @@ export class MCPController implements Resource {
       oauthTokensService,
       userSessionsService,
       userServerInstalls,
-      dcrClients
+      dcrClients,
+      serviceHmacProvider
     })
   }
 
@@ -136,6 +140,7 @@ export class MCPController implements Resource {
           description: server.description,
           source: server.source,
           authMode: server.authMode,
+          serviceHmacProfile: server.serviceHmacProfile,
           oauthTemplate: server.oauthTemplate,
           secretFields: server.secretFields,
           homepageUrl: server.homepageUrl,

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,5 +35,6 @@ export const env = {
   PYTHON_BIN: process.env.PYTHON_BIN,
   PYTHON_VENV_DIR: process.env.PYTHON_VENV_DIR || 'packages/python',
   PIP_INDEX_URL: process.env.PIP_INDEX_URL,
-  PIP_EXTRA_INDEX_URL: process.env.PIP_EXTRA_INDEX_URL
+  PIP_EXTRA_INDEX_URL: process.env.PIP_EXTRA_INDEX_URL,
+  MSQ_COMMS_MCP_HMAC_KEY_FILE: process.env.MSQ_COMMS_MCP_HMAC_KEY_FILE
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { McpUserSessions } from './services/userSessions'
 import { McpUserServerInstalls } from './services/userServerInstalls'
 import { McpDcrClients } from './services/dcrClients'
 import { ResourceStatsService } from './services/resourceStats'
+import { ServiceHmacProvider } from './services/serviceHmac'
 
 export type Resource = {
   init: () => Promise<void>
@@ -45,6 +46,14 @@ export class API {
     // Register built-in servers before initializing services
     registerBuiltInServers()
 
+    // This profile is optional at process scope. Missing or invalid key material
+    // blocks only service-HMAC MCP connections and leaves process liveness intact.
+    const serviceHmacProvider = new ServiceHmacProvider({
+      keyFilePath: env.MSQ_COMMS_MCP_HMAC_KEY_FILE
+    })
+    await serviceHmacProvider.init()
+    this.resources.push(serviceHmacProvider)
+
     // Initialize Secrets service
     const secretsService = new Secrets({ mongoParams })
     await secretsService.init()
@@ -71,7 +80,8 @@ export class API {
       oauthTokensService,
       userSessionsService,
       userServerInstalls,
-      dcrClients
+      dcrClients,
+      serviceHmacProvider
     })
     await mcpController.init()
     mcpController.registerRoutes()

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -8,7 +8,7 @@ import {
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { UnauthorizedError, type OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
-import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { Transport, type FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { Resource } from '..'
 import { BuiltInServer, BuiltInServerRegistry } from '../builtin-servers'
@@ -40,10 +40,17 @@ import {
   McpServerNotFoundError,
   McpAuthNotConnectedError,
   McpDiscoveryFailedError,
-  McpServerAlreadyExistsError
+  McpServerAlreadyExistsError,
+  McpServiceHmacUnavailableError
 } from './mcpErrors'
 import { validateExternalMcpUrl } from '../utils/ssrf'
 import { getStdioTransportPid } from '../utils/resourceStats'
+import {
+  COMMS_MANAGEMENT_HMAC_PROFILE,
+  COMMS_MANAGEMENT_MCP_URL,
+  type ServiceHmacProvider,
+  type ServiceHmacProfile
+} from './serviceHmac'
 
 export interface MCPConnection {
   client: Client
@@ -70,7 +77,7 @@ export type ToolsList = {
 
 export type MCPTransportType = 'stdio' | 'streamable_http'
 export type McpServerSource = 'platform' | 'external'
-export type McpServerAuthMode = 'none' | 'oauth2'
+export type McpServerAuthMode = 'none' | 'oauth2' | 'service_hmac'
 export type McpExternalOAuthDiscoverySource = 'prm' | 'issuer_override'
 
 export interface McpExternalOAuthAuthorizationRequestParam {
@@ -165,6 +172,7 @@ type MCPServerBase = {
   description?: string
   source?: McpServerSource
   authMode?: McpServerAuthMode
+  serviceHmacProfile?: ServiceHmacProfile
   oauthTemplate?: McpExternalOAuthTemplate
   secretFields?: McpExternalSecretField[]
   homepageUrl?: string
@@ -219,6 +227,7 @@ export type AddServerInput = {
   headers?: Record<string, string>
   reconnectionOptions?: StreamableHTTPReconnectionOptions
   authMode?: McpServerAuthMode
+  serviceHmacProfile?: ServiceHmacProfile
   oauthTemplate?: McpExternalOAuthTemplate
   secretFields?: McpExternalSecretField[]
   homepageUrl?: string
@@ -251,6 +260,7 @@ export type UpdateServerInput = {
   headers?: Record<string, string>
   reconnectionOptions?: StreamableHTTPReconnectionOptions
   authMode?: McpServerAuthMode
+  serviceHmacProfile?: ServiceHmacProfile
   oauthTemplate?: McpExternalOAuthTemplate
   secretFields?: McpExternalSecretField[]
   homepageUrl?: string
@@ -281,6 +291,7 @@ export interface UserVisibleMcpServer {
   transportType: MCPTransportType
   url?: string
   authMode?: McpServerAuthMode
+  serviceHmacProfile?: ServiceHmacProfile
   installed: boolean
   enabled: boolean
   authState?: UserInstallAuthState
@@ -382,6 +393,87 @@ export const assertTransportConfigCompatible = (config: {
     throw new Error('Stdio servers cannot define streamable HTTP fields (url, headers, sessionId, reconnectionOptions).')
   }
 }
+
+type ServiceHmacServerValidationState = {
+  source?: unknown
+  transportType?: unknown
+  authMode?: unknown
+  serviceHmacProfile?: unknown
+  url?: unknown
+  headers?: unknown
+  sessionId?: unknown
+  oauthTemplate?: unknown
+  oauthClientConfig?: unknown
+  oauthProvisioningContext?: unknown
+  secretFields?: unknown
+  secretName?: unknown
+  secretNames?: unknown
+  username?: unknown
+}
+
+export const assertServiceHmacServerConfiguration = (
+  config: ServiceHmacServerValidationState
+): void => {
+  const authMode = config.authMode ?? 'none'
+  if (authMode !== 'none' && authMode !== 'oauth2' && authMode !== 'service_hmac') {
+    throw new McpValidationError('Invalid MCP server authMode.')
+  }
+
+  const selectsServiceHmac = authMode === 'service_hmac' || config.serviceHmacProfile !== undefined
+  if (!selectsServiceHmac) {
+    return
+  }
+  if (authMode !== 'service_hmac') {
+    throw new McpValidationError('serviceHmacProfile requires authMode service_hmac.')
+  }
+  if (config.source !== 'platform') {
+    throw new McpValidationError('service_hmac requires source platform.')
+  }
+  if (config.transportType !== 'streamable_http') {
+    throw new McpValidationError('service_hmac requires streamable_http transport.')
+  }
+  if (config.serviceHmacProfile !== COMMS_MANAGEMENT_HMAC_PROFILE) {
+    throw new McpValidationError('service_hmac requires serviceHmacProfile comms_management.')
+  }
+  if (config.url !== COMMS_MANAGEMENT_MCP_URL) {
+    throw new McpValidationError(`service_hmac requires url ${COMMS_MANAGEMENT_MCP_URL}.`)
+  }
+
+  const forbiddenFields: Array<[keyof ServiceHmacServerValidationState, unknown]> = [
+    ['headers', config.headers],
+    ['sessionId', config.sessionId],
+    ['oauthTemplate', config.oauthTemplate],
+    ['oauthClientConfig', config.oauthClientConfig],
+    ['oauthProvisioningContext', config.oauthProvisioningContext],
+    ['secretFields', config.secretFields],
+    ['secretName', config.secretName],
+    ['secretNames', config.secretNames],
+    ['username', config.username]
+  ]
+  const configuredForbiddenFields = forbiddenFields
+    .filter(([, value]) => value !== undefined)
+    .map(([field]) => field)
+  if (configuredForbiddenFields.length > 0) {
+    throw new McpValidationError(
+      `service_hmac cannot define ${configuredForbiddenFields.join(', ')}.`
+    )
+  }
+}
+
+export type ServiceHmacMcpServer = MCPServer &
+  StreamableHttpServerConfig & {
+    source: 'platform'
+    authMode: 'service_hmac'
+    serviceHmacProfile: typeof COMMS_MANAGEMENT_HMAC_PROFILE
+    url: typeof COMMS_MANAGEMENT_MCP_URL
+  }
+
+export const isServiceHmacServer = (server: MCPServer): server is ServiceHmacMcpServer =>
+  server.source === 'platform' &&
+  server.transportType === 'streamable_http' &&
+  server.authMode === 'service_hmac' &&
+  server.serviceHmacProfile === COMMS_MANAGEMENT_HMAC_PROFILE &&
+  server.url === COMMS_MANAGEMENT_MCP_URL
 
 const isStreamableHTTPTransport = (transport: Transport): transport is StreamableHTTPClientTransport =>
   typeof (transport as StreamableHTTPClientTransport).terminateSession === 'function'
@@ -817,6 +909,7 @@ const summarizeUrlForLog = (value: string | undefined): string | undefined => {
 export type TransportFactoryOptions = {
   requestInit?: RequestInit
   authProvider?: OAuthClientProvider
+  fetch?: FetchLike
   sessionId?: string
   url?: string
 }
@@ -828,7 +921,8 @@ export const createTransport = (server: MCPServer, options: TransportFactoryOpti
       requestInit,
       sessionId: options.sessionId,
       reconnectionOptions: server.reconnectionOptions,
-      authProvider: options.authProvider
+      authProvider: options.authProvider,
+      fetch: options.fetch
     })
   }
 
@@ -840,14 +934,15 @@ export const createTransport = (server: MCPServer, options: TransportFactoryOpti
   })
 }
 
-const createSseTransport = (
+export const createSseTransport = (
   server: StreamableHttpServerConfig,
   options: TransportFactoryOptions = {}
 ): Transport => {
   const requestInit = options.requestInit ?? buildRequestInit(server.headers)
   return new SSEClientTransport(new URL(options.url ?? server.url), {
     requestInit,
-    authProvider: options.authProvider
+    authProvider: options.authProvider,
+    fetch: options.fetch
   })
 }
 
@@ -955,6 +1050,7 @@ export class MCPService implements Resource {
   private oauthTokensService?: McpOAuthTokens
   private userSessionsService?: McpUserSessions
   private dcrClients?: McpDcrClients
+  private serviceHmacProvider?: ServiceHmacProvider
   public userServerInstalls: McpUserServerInstalls
   private mongoParams: MongoConnectionParams
   private packageService?: any // Will be set after initialization to avoid circular dependency
@@ -965,7 +1061,8 @@ export class MCPService implements Resource {
     oauthTokensService,
     userSessionsService,
     userServerInstalls,
-    dcrClients
+    dcrClients,
+    serviceHmacProvider
   }: {
     mongoParams: MongoConnectionParams
     secretsService: Secrets
@@ -973,6 +1070,7 @@ export class MCPService implements Resource {
     userSessionsService?: McpUserSessions
     userServerInstalls: McpUserServerInstalls
     dcrClients?: McpDcrClients
+    serviceHmacProvider?: ServiceHmacProvider
   }) {
     this.mongoParams = mongoParams
     this.mcpDBClient = new MongoDBClient<MCPServerRecord>(mongoParams, mcpIndexes)
@@ -981,6 +1079,7 @@ export class MCPService implements Resource {
     this.userSessionsService = userSessionsService
     this.userServerInstalls = userServerInstalls
     this.dcrClients = dcrClients
+    this.serviceHmacProvider = serviceHmacProvider
   }
 
   private async fetchDiscoveryResponse(url: string, discoveryDeadlineMs: number): Promise<Response> {
@@ -1638,6 +1737,7 @@ export class MCPService implements Resource {
   }
 
   private async normalizeServerRecord(server: MCPServerRecord): Promise<MCPServer> {
+    assertServiceHmacServerConfiguration(server)
     const withSecrets = await this.migrateServerSecrets(server)
     if (this.shouldBackfillExternalOAuthResourceUri(withSecrets)) {
       this.scheduleExternalOAuthResourceUriBackfill(withSecrets)
@@ -1653,6 +1753,12 @@ export class MCPService implements Resource {
   private async buildTransportOptions(server: MCPServer, username?: string): Promise<TransportFactoryOptions> {
     if (server.transportType !== 'streamable_http') {
       return {}
+    }
+
+    assertServiceHmacServerConfiguration(server)
+    if (isServiceHmacServer(server)) {
+      this.assertServiceHmacReady()
+      return { fetch: this.serviceHmacProvider!.createSignedFetch() }
     }
 
     const runtimeUrl =
@@ -1709,6 +1815,13 @@ export class MCPService implements Resource {
       requestInit: buildRequestInit(sanitizedHeaders ?? {}),
       ...(runtimeUrl ? { url: runtimeUrl } : {})
     }
+  }
+
+  private assertServiceHmacReady(): void {
+    if (!this.serviceHmacProvider) {
+      throw new McpServiceHmacUnavailableError(COMMS_MANAGEMENT_HMAC_PROFILE)
+    }
+    this.serviceHmacProvider.assertReady()
   }
 
   private async persistUserSessionId(
@@ -2013,6 +2126,7 @@ export class MCPService implements Resource {
       source,
       transportType: server.transportType,
       authMode,
+      serviceHmacProfile: server.serviceHmacProfile,
       installed,
       enabled,
       authState,
@@ -2415,6 +2529,11 @@ export class MCPService implements Resource {
       throw new Error(`connectUserToServer is only for streamable_http servers, got ${server.transportType}`)
     }
 
+    assertServiceHmacServerConfiguration(server)
+    if (isServiceHmacServer(server)) {
+      this.assertServiceHmacReady()
+    }
+
     const userKey = buildUserServerKey(username, server.name)
 
     // Check if already connected
@@ -2447,7 +2566,12 @@ export class MCPService implements Resource {
       throw new Error(`connectUserToServer is only for streamable_http servers, got ${server.transportType}`)
     }
 
-    await validateExternalMcpUrl(server.url)
+    assertServiceHmacServerConfiguration(server)
+    if (isServiceHmacServer(server)) {
+      this.assertServiceHmacReady()
+    } else {
+      await validateExternalMcpUrl(server.url)
+    }
 
     const userKey = buildUserServerKey(username, server.name)
 
@@ -2477,6 +2601,9 @@ export class MCPService implements Resource {
       const conn = this.userConnections[userKey]
       if (conn) {
         appendServerLog(conn.logs, error.message)
+        if (error instanceof McpServiceHmacUnavailableError) {
+          conn.status = 'error'
+        }
       }
     }
 
@@ -2488,12 +2615,17 @@ export class MCPService implements Resource {
       }
     }
 
+    let serviceHmacTransportOptions: TransportFactoryOptions | undefined
+
     try {
       const client = new Client(
         { name: 'MSQStdioClient', version: '1.0.0' },
         { capabilities: { prompts: {}, resources: {}, tools: {} } }
       )
       const transportOptions = await this.buildTransportOptions(server, username)
+      if (isServiceHmacServer(server)) {
+        serviceHmacTransportOptions = transportOptions
+      }
       const transport = createTransport(server, { ...transportOptions, sessionId })
 
       const userConn: UserConnection = {
@@ -2583,7 +2715,8 @@ export class MCPService implements Resource {
           { name: 'MSQStdioClient', version: '1.0.0' },
           { capabilities: { prompts: {}, resources: {}, tools: {} } }
         )
-        const transportOptions = await this.buildTransportOptions(server, username)
+        const transportOptions =
+          serviceHmacTransportOptions ?? await this.buildTransportOptions(server, username)
         const fallbackTransport = createSseTransport(server, transportOptions)
 
         fallbackTransport.onerror = transportErrorHandler
@@ -2940,7 +3073,7 @@ export class MCPService implements Resource {
 
     const install = await this.userServerInstalls.upsertInstall({
       ...input,
-      authMode: server.authMode ?? 'none'
+      authMode: server.authMode === 'oauth2' ? 'oauth2' : 'none'
     })
     return this.toUserVisibleServer(
       server,
@@ -2983,7 +3116,7 @@ export class MCPService implements Resource {
 
     const install = await this.userServerInstalls.upsertInstall({
       ...input,
-      authMode: server.authMode ?? 'none'
+      authMode: server.authMode === 'oauth2' ? 'oauth2' : 'none'
     })
     if (oauthConfigChanged) {
       if (this.oauthTokensService) {
@@ -3164,6 +3297,13 @@ export class MCPService implements Resource {
     const source: McpServerSource = serverData.source ?? 'platform'
     const sharedSessionId = (serverData as AddServerInput & { sessionId?: unknown }).sessionId
 
+    assertServiceHmacServerConfiguration({
+      ...serverData,
+      source,
+      transportType,
+      sessionId: sharedSessionId
+    })
+
     assertTransportConfigCompatible({
       transportType,
       command: serverData.command,
@@ -3184,6 +3324,7 @@ export class MCPService implements Resource {
       displayName,
       description,
       authMode,
+      serviceHmacProfile,
       oauthTemplate,
       secretFields,
       homepageUrl,
@@ -3315,9 +3456,10 @@ export class MCPService implements Resource {
         displayName: displayName ?? name,
         description: description ?? '',
         source,
-        authMode: source === 'external' ? authMode ?? 'none' : 'none',
+        authMode: authMode === 'service_hmac' ? 'service_hmac' : source === 'external' ? authMode ?? 'none' : 'none',
+        serviceHmacProfile,
         oauthTemplate: normalizedOauthTemplate,
-        secretFields: effectiveSecretFields ?? [],
+        secretFields: authMode === 'service_hmac' ? undefined : effectiveSecretFields ?? [],
         homepageUrl,
         repositoryUrl,
         licenseName,
@@ -3369,6 +3511,7 @@ export class MCPService implements Resource {
       }
     }
 
+    assertServiceHmacServerConfiguration(server)
     await this.mcpDBClient.insert(server)
 
     if (source === 'external' && username) {
@@ -3376,7 +3519,7 @@ export class MCPService implements Resource {
         serverName: name,
         username,
         enabled,
-        authMode: authMode ?? 'none',
+        authMode: authMode === 'oauth2' ? 'oauth2' : 'none',
         oauthClientId: serverData.oauthClientConfig?.clientId,
         oauthClientSecret: serverData.oauthClientConfig?.clientSecret,
         oauthScopes: serverData.oauthClientConfig?.scopes
@@ -3422,13 +3565,29 @@ export class MCPService implements Resource {
       throw new Error(`Server with name ${name} not found`)
     }
 
+    const nextTransportType: MCPTransportType =
+      serverData.transportType ?? existingRecord.transportType ?? 'stdio'
+    assertServiceHmacServerConfiguration({
+      source: serverData.source ?? existingRecord.source,
+      transportType: nextTransportType,
+      authMode: serverData.authMode ?? existingRecord.authMode,
+      serviceHmacProfile: serverData.serviceHmacProfile ?? existingRecord.serviceHmacProfile,
+      url: serverData.url ?? existingRecord.url,
+      headers: serverData.headers ?? existingRecord.headers,
+      sessionId: sharedSessionId ?? existingRecord.sessionId,
+      oauthTemplate: serverData.oauthTemplate ?? existingRecord.oauthTemplate,
+      secretFields: serverData.secretFields ?? existingRecord.secretFields,
+      secretName: serverData.secretName ?? existingRecord.secretName,
+      secretNames: serverData.secretNames ?? existingRecord.secretNames,
+      username: serverData.username
+    })
+
     const existingServer = await this.normalizeServerRecord({
       ...existingRecord,
       status: existingRecord.status ?? 'disconnected',
       enabled: existingRecord.enabled !== false
     })
 
-    const nextTransportType: MCPTransportType = serverData.transportType ?? existingServer.transportType
     assertTransportConfigCompatible({
       transportType: nextTransportType,
       command: serverData.command,
@@ -3469,6 +3628,7 @@ export class MCPService implements Resource {
       description: serverData.description ?? existingServer.description,
       source: serverData.source ?? existingServer.source,
       authMode: serverData.authMode ?? existingServer.authMode,
+      serviceHmacProfile: serverData.serviceHmacProfile ?? existingServer.serviceHmacProfile,
       oauthTemplate: serverData.oauthTemplate ?? existingServer.oauthTemplate,
       secretFields: serverData.secretFields ?? existingServer.secretFields,
       homepageUrl: serverData.homepageUrl ?? existingServer.homepageUrl,
@@ -3507,15 +3667,7 @@ export class MCPService implements Resource {
       if (!url) {
         throw new Error('Streamable HTTP servers require a url.')
       }
-      if ((baseServer.source ?? 'platform') === 'external') {
-        const knownProviderUrlError = getKnownProviderUrlError(url)
-        if (knownProviderUrlError) {
-          throw new McpValidationError(knownProviderUrlError)
-        }
-        await validateExternalMcpUrl(url)
-      } else {
-        new URL(url)
-      }
+      new URL(url)
 
       updatedServer = {
         ...baseServer,
@@ -3545,7 +3697,12 @@ export class MCPService implements Resource {
       }
     }
 
+    assertServiceHmacServerConfiguration(updatedServer)
     if ((updatedServer.source ?? 'platform') === 'external' && updatedServer.transportType === 'streamable_http') {
+      const knownProviderUrlError = getKnownProviderUrlError(updatedServer.url)
+      if (knownProviderUrlError) {
+        throw new McpValidationError(knownProviderUrlError)
+      }
       await validateExternalMcpUrl(updatedServer.url)
       const normalizedOauthTemplate = await this.normalizeExternalOAuthTemplateForPersistence(
         updatedServer.authMode ?? 'none',
@@ -3629,6 +3786,9 @@ export class MCPService implements Resource {
     }
     if (server.transportType !== 'streamable_http') {
       throw new Error(`Server ${name} is not a streamable HTTP server`)
+    }
+    if (server.authMode === 'service_hmac') {
+      throw new McpValidationError('service_hmac servers do not accept user OAuth configuration')
     }
 
     const tokenType = input.tokenType || 'Bearer'

--- a/src/services/mcpErrors.ts
+++ b/src/services/mcpErrors.ts
@@ -4,6 +4,7 @@ export type McpErrorCode =
   | 'server_disabled'
   | 'auth_not_connected'
   | 'reauth_required'
+  | 'service_unavailable'
   | 'server_already_exists'
   | 'discovery_failed'
 
@@ -15,6 +16,7 @@ export type McpErrorResponseBody = {
   serverName?: string
   username?: string
   authorizationUrl?: string
+  serviceHmacProfile?: string
   server?: unknown
   attemptedUrls?: string[]
   cause?: string
@@ -107,6 +109,20 @@ export class McpReauthRequiredError extends McpApiError {
         username,
         authorizationUrl
       }
+    })
+  }
+}
+
+export class McpServiceHmacUnavailableError extends McpApiError {
+  constructor(
+    serviceHmacProfile: string,
+    message = `Service-HMAC profile ${serviceHmacProfile} is unavailable.`
+  ) {
+    super({
+      message,
+      code: 'service_unavailable',
+      statusCode: 503,
+      details: { serviceHmacProfile }
     })
   }
 }

--- a/src/services/serviceHmac.ts
+++ b/src/services/serviceHmac.ts
@@ -1,0 +1,450 @@
+import { constants as fsConstants } from 'fs'
+import { open } from 'fs/promises'
+import { isAbsolute } from 'path'
+import { createHash, createHmac, randomBytes } from 'crypto'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { log } from '../utils/general'
+import { McpServiceHmacUnavailableError } from './mcpErrors'
+
+export const COMMS_MANAGEMENT_HMAC_PROFILE = 'comms_management' as const
+export const COMMS_MANAGEMENT_MCP_URL = 'https://comms-management:8080/internal/mcp' as const
+const COMMS_MANAGEMENT_MCP_ORIGIN = 'https://comms-management:8080'
+const COMMS_MANAGEMENT_MCP_PATHNAME = '/internal/mcp'
+
+export type ServiceHmacProfile = typeof COMMS_MANAGEMENT_HMAC_PROFILE
+export type ServiceHmacClock = () => number
+export type ServiceHmacNonceSource = () => Uint8Array
+
+export interface SymmetricKey {
+  kid: string
+  state: 'active' | 'previous'
+  key: Buffer
+  notBeforeUnixSeconds: number
+  verifyUntilUnixSeconds: number
+}
+
+export interface SymmetricKeyring {
+  version: '1'
+  activeKid: string
+  keys: SymmetricKey[]
+}
+
+interface ParsedDateTime {
+  unixSeconds: number
+}
+
+const KEYRING_TOP_LEVEL_KEYS = new Set(['version', 'activeKid', 'keys'])
+const KEYRING_KEY_KEYS = new Set(['kid', 'state', 'keyBase64url', 'notBefore', 'verifyUntil'])
+const KID_PATTERN = /^[A-Za-z0-9._-]{1,64}$/
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/
+const RFC3339_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/
+const ALLOWED_FILE_MODES = new Set([0o400, 0o440])
+const ALLOWED_METHODS = new Set(['POST', 'GET', 'DELETE'])
+const RESERVED_HEADER_PREFIX = 'x-msq-'
+
+class ServiceHmacKeyringError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ServiceHmacKeyringError'
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+function assertClosedObject(
+  value: unknown,
+  allowedKeys: ReadonlySet<string>,
+  context: string
+): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new ServiceHmacKeyringError(`${context} must be an object.`)
+  }
+  const unknownKey = Object.keys(value).find((key) => !allowedKeys.has(key))
+  if (unknownKey) {
+    throw new ServiceHmacKeyringError(`${context} contains an unknown property.`)
+  }
+}
+
+const parseRfc3339 = (value: unknown, context: string): ParsedDateTime => {
+  if (typeof value !== 'string') {
+    throw new ServiceHmacKeyringError(`${context} must be an RFC 3339 date-time string.`)
+  }
+  const match = RFC3339_PATTERN.exec(value)
+  if (!match) {
+    throw new ServiceHmacKeyringError(`${context} must be an RFC 3339 date-time string.`)
+  }
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , offset] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  const second = Number(secondText)
+  const offsetHour = offset === 'Z' ? 0 : Number(offset.slice(1, 3))
+  const offsetMinute = offset === 'Z' ? 0 : Number(offset.slice(4, 6))
+  const daysInMonth = month >= 1 && month <= 12 ? new Date(Date.UTC(year, month, 0)).getUTCDate() : 0
+
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    throw new ServiceHmacKeyringError(`${context} must be a valid RFC 3339 date-time string.`)
+  }
+
+  const milliseconds = Date.parse(value)
+  if (!Number.isFinite(milliseconds)) {
+    throw new ServiceHmacKeyringError(`${context} must be a valid RFC 3339 date-time string.`)
+  }
+  return { unixSeconds: milliseconds / 1000 }
+}
+
+const parseKey = (value: unknown, index: number): SymmetricKey => {
+  const context = `keys[${index}]`
+  assertClosedObject(value, KEYRING_KEY_KEYS, context)
+
+  const { kid, state, keyBase64url, notBefore, verifyUntil } = value
+  if (typeof kid !== 'string' || !KID_PATTERN.test(kid)) {
+    throw new ServiceHmacKeyringError(`${context}.kid is invalid.`)
+  }
+  if (state !== 'active' && state !== 'previous') {
+    throw new ServiceHmacKeyringError(`${context}.state is invalid.`)
+  }
+  if (typeof keyBase64url !== 'string' || !BASE64URL_PATTERN.test(keyBase64url)) {
+    throw new ServiceHmacKeyringError(`${context}.keyBase64url must be unpadded base64url.`)
+  }
+
+  const key = Buffer.from(keyBase64url, 'base64url')
+  if (key.length !== 32 || key.toString('base64url') !== keyBase64url) {
+    throw new ServiceHmacKeyringError(`${context}.keyBase64url must encode exactly 32 bytes.`)
+  }
+
+  const parsedNotBefore = parseRfc3339(notBefore, `${context}.notBefore`)
+  const parsedVerifyUntil = parseRfc3339(verifyUntil, `${context}.verifyUntil`)
+  if (parsedNotBefore.unixSeconds >= parsedVerifyUntil.unixSeconds) {
+    throw new ServiceHmacKeyringError(`${context} must satisfy notBefore < verifyUntil.`)
+  }
+
+  return {
+    kid,
+    state,
+    key,
+    notBeforeUnixSeconds: parsedNotBefore.unixSeconds,
+    verifyUntilUnixSeconds: parsedVerifyUntil.unixSeconds
+  }
+}
+
+export const parseSymmetricKeyring = (json: string): SymmetricKeyring => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new ServiceHmacKeyringError('Keyring must contain valid JSON.')
+  }
+
+  assertClosedObject(parsed, KEYRING_TOP_LEVEL_KEYS, 'Keyring')
+  if (parsed.version !== '1') {
+    throw new ServiceHmacKeyringError('Keyring.version must equal "1".')
+  }
+  if (typeof parsed.activeKid !== 'string' || !KID_PATTERN.test(parsed.activeKid)) {
+    throw new ServiceHmacKeyringError('Keyring.activeKid is invalid.')
+  }
+  if (!Array.isArray(parsed.keys) || parsed.keys.length < 1 || parsed.keys.length > 2) {
+    throw new ServiceHmacKeyringError('Keyring.keys must contain one or two keys.')
+  }
+
+  const keys = parsed.keys.map(parseKey)
+  if (new Set(keys.map(({ kid }) => kid)).size !== keys.length) {
+    throw new ServiceHmacKeyringError('Keyring kids must be unique.')
+  }
+  const activeKeys = keys.filter(({ state }) => state === 'active')
+  const previousKeys = keys.filter(({ state }) => state === 'previous')
+  if (activeKeys.length !== 1 || previousKeys.length > 1) {
+    throw new ServiceHmacKeyringError('Keyring must contain exactly one active key and at most one previous key.')
+  }
+  if (activeKeys[0].kid !== parsed.activeKid) {
+    throw new ServiceHmacKeyringError('Keyring.activeKid must match the active key.')
+  }
+
+  return {
+    version: '1',
+    activeKid: parsed.activeKid,
+    keys
+  }
+}
+
+export const loadSymmetricKeyringFile = async (keyFilePath: string): Promise<SymmetricKeyring> => {
+  if (!isAbsolute(keyFilePath)) {
+    throw new ServiceHmacKeyringError('The service-HMAC key file path must be absolute.')
+  }
+
+  let fileHandle
+  try {
+    fileHandle = await open(keyFilePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+  } catch {
+    throw new ServiceHmacKeyringError('The service-HMAC key file could not be opened securely.')
+  }
+
+  try {
+    const stats = await fileHandle.stat()
+    if (!stats.isFile()) {
+      throw new ServiceHmacKeyringError('The service-HMAC key file must be a regular file.')
+    }
+    const mode = stats.mode & 0o7777
+    if (!ALLOWED_FILE_MODES.has(mode)) {
+      throw new ServiceHmacKeyringError('The service-HMAC key file mode must be 0400 or 0440.')
+    }
+    return parseSymmetricKeyring(await fileHandle.readFile({ encoding: 'utf8' }))
+  } finally {
+    await fileHandle.close()
+  }
+}
+
+const getActiveKey = (keyring: SymmetricKeyring, unixSeconds: number): SymmetricKey | undefined => {
+  const activeKey = keyring.keys.find(({ state }) => state === 'active')
+  if (
+    !activeKey ||
+    activeKey.kid !== keyring.activeKid ||
+    unixSeconds < activeKey.notBeforeUnixSeconds ||
+    unixSeconds >= activeKey.verifyUntilUnixSeconds
+  ) {
+    return undefined
+  }
+  return activeKey
+}
+
+type RequestBody = RequestInit['body']
+
+interface NormalizedBody {
+  bytes: Uint8Array
+  body: RequestBody
+}
+
+const normalizeBody = (body: RequestBody): NormalizedBody => {
+  if (body === undefined || body === null) {
+    return { bytes: new Uint8Array(0), body }
+  }
+  if (typeof body === 'string') {
+    return { bytes: Buffer.from(body, 'utf8'), body }
+  }
+  if (body instanceof ArrayBuffer) {
+    const bytes = new Uint8Array(body.slice(0))
+    return { bytes, body: bytes }
+  }
+  if (ArrayBuffer.isView(body)) {
+    const bytes = new Uint8Array(body.byteLength)
+    bytes.set(new Uint8Array(body.buffer, body.byteOffset, body.byteLength))
+    return { bytes, body: bytes }
+  }
+  throw new McpServiceHmacUnavailableError(
+    COMMS_MANAGEMENT_HMAC_PROFILE,
+    'The service-HMAC transport does not support this request body type.'
+  )
+}
+
+const resolveRequestUrl = (input: string | URL): URL => {
+  let url: URL
+  try {
+    url = new URL(input.toString())
+  } catch {
+    throw new McpServiceHmacUnavailableError(
+      COMMS_MANAGEMENT_HMAC_PROFILE,
+      'The service-HMAC transport received an invalid request URL.'
+    )
+  }
+
+  if (
+    url.origin !== COMMS_MANAGEMENT_MCP_ORIGIN ||
+    url.pathname !== COMMS_MANAGEMENT_MCP_PATHNAME ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.hash !== ''
+  ) {
+    throw new McpServiceHmacUnavailableError(
+      COMMS_MANAGEMENT_HMAC_PROFILE,
+      'The service-HMAC transport rejected an out-of-profile request URL.'
+    )
+  }
+  return url
+}
+
+export interface ServiceHmacProviderOptions {
+  keyFilePath?: string
+  clock?: ServiceHmacClock
+  nonceSource?: ServiceHmacNonceSource
+  fetch?: FetchLike
+}
+
+export class ServiceHmacProvider {
+  private readonly keyFilePath?: string
+  private readonly clock: ServiceHmacClock
+  private readonly nonceSource: ServiceHmacNonceSource
+  private readonly underlyingFetch: FetchLike
+  private readonly sighupHandler: () => void
+  private keyring?: SymmetricKeyring
+  private available = false
+  private initialized = false
+  private reloadQueue: Promise<void> = Promise.resolve()
+
+  constructor({
+    keyFilePath,
+    clock = () => Math.floor(Date.now() / 1000),
+    nonceSource = () => randomBytes(16),
+    fetch: fetchImplementation = (url, init) => globalThis.fetch(url, init)
+  }: ServiceHmacProviderOptions = {}) {
+    this.keyFilePath = keyFilePath
+    this.clock = clock
+    this.nonceSource = nonceSource
+    this.underlyingFetch = fetchImplementation
+    this.sighupHandler = () => {
+      void this.reload()
+    }
+  }
+
+  public async init(): Promise<void> {
+    if (!this.initialized) {
+      process.on('SIGHUP', this.sighupHandler)
+      this.initialized = true
+    }
+    await this.reload()
+  }
+
+  public async stop(): Promise<void> {
+    if (this.initialized) {
+      process.removeListener('SIGHUP', this.sighupHandler)
+      this.initialized = false
+    }
+  }
+
+  public reload(): Promise<void> {
+    this.reloadQueue = this.reloadQueue.then(() => this.reloadCandidate())
+    return this.reloadQueue
+  }
+
+  public isReady(): boolean {
+    if (!this.available || !this.keyring) {
+      return false
+    }
+    return getActiveKey(this.keyring, this.readClock()) !== undefined
+  }
+
+  public assertReady(): void {
+    if (!this.isReady()) {
+      throw new McpServiceHmacUnavailableError(COMMS_MANAGEMENT_HMAC_PROFILE)
+    }
+  }
+
+  public createSignedFetch(): FetchLike {
+    return async (input, init) => {
+      const url = resolveRequestUrl(input)
+      const method = init?.method ?? 'GET'
+      if (!ALLOWED_METHODS.has(method)) {
+        throw new McpServiceHmacUnavailableError(
+          COMMS_MANAGEMENT_HMAC_PROFILE,
+          'The service-HMAC transport rejected an unsupported HTTP method.'
+        )
+      }
+
+      const normalizedBody = normalizeBody(init?.body)
+      const headers = new Headers(init?.headers)
+      for (const [name] of headers.entries()) {
+        if (name.toLowerCase().startsWith(RESERVED_HEADER_PREFIX)) {
+          throw new McpServiceHmacUnavailableError(
+            COMMS_MANAGEMENT_HMAC_PROFILE,
+            'The service-HMAC transport rejected a caller-supplied authentication header.'
+          )
+        }
+      }
+
+      const timestamp = this.readClock()
+      const activeKey = this.available && this.keyring ? getActiveKey(this.keyring, timestamp) : undefined
+      if (!activeKey) {
+        throw new McpServiceHmacUnavailableError(COMMS_MANAGEMENT_HMAC_PROFILE)
+      }
+
+      let nonceBytes: Uint8Array
+      try {
+        nonceBytes = this.nonceSource()
+      } catch {
+        throw new McpServiceHmacUnavailableError(
+          COMMS_MANAGEMENT_HMAC_PROFILE,
+          'The service-HMAC nonce source failed.'
+        )
+      }
+      if (nonceBytes.byteLength !== 16) {
+        throw new McpServiceHmacUnavailableError(
+          COMMS_MANAGEMENT_HMAC_PROFILE,
+          'The service-HMAC nonce source did not return 16 bytes.'
+        )
+      }
+      const nonce = Buffer.from(nonceBytes).toString('base64url')
+      const bodySha256 = createHash('sha256').update(normalizedBody.bytes).digest('hex')
+      const pathnameAndQuery = `${url.pathname}${url.search}`
+      const signingString = `v1\n${method}\n${pathnameAndQuery}\n${timestamp}\n${nonce}\n${bodySha256}`
+      const signature = createHmac('sha256', activeKey.key).update(signingString, 'utf8').digest('base64url')
+
+      headers.set('X-MSQ-Key-Id', activeKey.kid)
+      headers.set('X-MSQ-Timestamp', timestamp.toString())
+      headers.set('X-MSQ-Nonce', nonce)
+      headers.set('X-MSQ-Body-SHA256', bodySha256)
+      headers.set('X-MSQ-Signature', signature)
+
+      return this.underlyingFetch(url, {
+        ...init,
+        method,
+        headers,
+        body: normalizedBody.body,
+        redirect: 'error'
+      })
+    }
+  }
+
+  private readClock(): number {
+    let clockValue: number
+    try {
+      clockValue = this.clock()
+    } catch {
+      throw new McpServiceHmacUnavailableError(
+        COMMS_MANAGEMENT_HMAC_PROFILE,
+        'The service-HMAC clock failed.'
+      )
+    }
+    const timestamp = Math.floor(clockValue)
+    if (!Number.isSafeInteger(timestamp) || timestamp < 0) {
+      throw new McpServiceHmacUnavailableError(
+        COMMS_MANAGEMENT_HMAC_PROFILE,
+        'The service-HMAC clock did not return valid Unix seconds.'
+      )
+    }
+    return timestamp
+  }
+
+  private async reloadCandidate(): Promise<void> {
+    if (!this.keyFilePath) {
+      this.available = false
+      log({ level: 'warn', msg: 'Service-HMAC profile unavailable: key file is not configured.' })
+      return
+    }
+
+    try {
+      const candidate = await loadSymmetricKeyringFile(this.keyFilePath)
+      if (!getActiveKey(candidate, this.readClock())) {
+        throw new ServiceHmacKeyringError('The active service-HMAC key is outside its signing window.')
+      }
+      this.keyring = candidate
+      this.available = true
+      log({ level: 'info', msg: `Service-HMAC profile keyring loaded (kid ${candidate.activeKid}).` })
+    } catch {
+      this.available = false
+      log({ level: 'warn', msg: 'Service-HMAC profile unavailable: keyring validation failed.' })
+    }
+  }
+}

--- a/test/mcp-external-auth.spec.ts
+++ b/test/mcp-external-auth.spec.ts
@@ -803,6 +803,10 @@ describe('external MCP error contract', () => {
         return new Response('Not Found', { status: 404 })
       }
 
+      if (url === 'https://example.com/.well-known/oauth-authorization-server/mcp') {
+        return new Response('Not Found', { status: 404 })
+      }
+
       if (url === 'https://example.com/.well-known/oauth-authorization-server') {
         return new Response(
           JSON.stringify({

--- a/test/mcp-external-auth.spec.ts
+++ b/test/mcp-external-auth.spec.ts
@@ -2,6 +2,7 @@ import { requireUsername } from '../src/controllers/mcp'
 import {
   MCPService,
   resolveUserConnectionTeardownPolicy,
+  assertServiceHmacServerConfiguration,
   assertTransportConfigCompatible,
   buildAuthorizationServerMetadataCandidates,
   buildMergedAuthorizationServerResult,
@@ -30,6 +31,7 @@ import {
   resolvePreferredTokenEndpointAuthMethod
 } from '../src/services/dcrClients'
 import { validateExternalMcpUrl } from '../src/utils/ssrf'
+import { COMMS_MANAGEMENT_MCP_URL } from '../src/services/serviceHmac'
 
 const originalFetch = global.fetch
 
@@ -51,6 +53,84 @@ describe('external MCP request validation', () => {
         sessionId: 'shared-session'
       })
     ).toThrow('Streamable HTTP server definitions cannot define sessionId')
+  })
+
+  test('accepts only the closed platform comms_management service-HMAC server state', () => {
+    expect(() =>
+      assertServiceHmacServerConfiguration({
+        source: 'platform',
+        transportType: 'streamable_http',
+        authMode: 'service_hmac',
+        serviceHmacProfile: 'comms_management',
+        url: COMMS_MANAGEMENT_MCP_URL
+      })
+    ).not.toThrow()
+  })
+
+  test.each([
+    ['external source', { source: 'external' }],
+    ['stdio transport', { transportType: 'stdio' }],
+    ['missing profile', { serviceHmacProfile: undefined }],
+    ['alternate profile', { serviceHmacProfile: 'other' }],
+    ['alternate origin', { url: 'https://other:8080/internal/mcp' }],
+    ['alternate port', { url: 'https://comms-management:8443/internal/mcp' }],
+    ['alternate path', { url: 'https://comms-management:8080/mcp' }],
+    ['configured query', { url: `${COMMS_MANAGEMENT_MCP_URL}?session=static` }],
+    ['configured fragment', { url: `${COMMS_MANAGEMENT_MCP_URL}#fragment` }],
+    ['static headers', { headers: { Authorization: 'Bearer forbidden' } }],
+    ['shared session', { sessionId: 'shared' }],
+    ['OAuth template', { oauthTemplate: {} }],
+    ['OAuth client', { oauthClientConfig: { clientId: 'client' } }],
+    ['OAuth provisioning', { oauthProvisioningContext: {} }],
+    ['external secret fields', { secretFields: [] }],
+    ['external secret name', { secretName: 'TOKEN' }],
+    ['external secret names', { secretNames: [] }],
+    ['user selection', { username: 'alice' }]
+  ])('rejects service-HMAC with %s', (_name, override) => {
+    expect(() =>
+      assertServiceHmacServerConfiguration({
+        source: 'platform',
+        transportType: 'streamable_http',
+        authMode: 'service_hmac',
+        serviceHmacProfile: 'comms_management',
+        url: COMMS_MANAGEMENT_MCP_URL,
+        ...override
+      })
+    ).toThrow(McpValidationError)
+  })
+
+  test.each(['none', 'oauth2'])('rejects serviceHmacProfile with %s auth', (authMode) => {
+    expect(() =>
+      assertServiceHmacServerConfiguration({
+        source: 'platform',
+        transportType: 'streamable_http',
+        authMode,
+        serviceHmacProfile: 'comms_management',
+        url: COMMS_MANAGEMENT_MCP_URL
+      })
+    ).toThrow('serviceHmacProfile requires authMode service_hmac')
+  })
+
+  test('preserves existing none and OAuth server defaults when the service selector is absent', () => {
+    expect(() => assertServiceHmacServerConfiguration({})).not.toThrow()
+    expect(() =>
+      assertServiceHmacServerConfiguration({
+        source: 'external',
+        transportType: 'streamable_http',
+        authMode: 'none',
+        url: 'https://example.com/mcp',
+        headers: { 'X-Existing': 'preserved' }
+      })
+    ).not.toThrow()
+    expect(() =>
+      assertServiceHmacServerConfiguration({
+        source: 'external',
+        transportType: 'streamable_http',
+        authMode: 'oauth2',
+        url: 'https://example.com/mcp',
+        oauthTemplate: {}
+      })
+    ).not.toThrow()
   })
 
   test('parses RFC 9728 challenge metadata and scope hints', () => {

--- a/test/mcp-service-hmac.spec.ts
+++ b/test/mcp-service-hmac.spec.ts
@@ -1,0 +1,634 @@
+import { createHash, createHmac } from 'crypto'
+import { chmod, mkdtemp, rename, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { McpServiceHmacUnavailableError, toMcpErrorResponse } from '../src/services/mcpErrors'
+import { MCPService } from '../src/services/mcp'
+import {
+  COMMS_MANAGEMENT_MCP_URL,
+  ServiceHmacProvider,
+  loadSymmetricKeyringFile,
+  parseSymmetricKeyring
+} from '../src/services/serviceHmac'
+
+const FIXED_UNIX_SECONDS = 1_700_000_000
+const EMPTY_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+const ACTIVE_KEY = Buffer.alloc(32, 0x11)
+
+interface KeyFixture {
+  kid: string
+  state: 'active' | 'previous'
+  keyBase64url: string
+  notBefore: string
+  verifyUntil: string
+}
+
+interface CapturedRequest {
+  url: URL
+  method: string
+  headers: Headers
+  body: RequestInit['body']
+  redirect: RequestInit['redirect']
+}
+
+const temporaryDirectories: string[] = []
+const providers: ServiceHmacProvider[] = []
+
+const createKey = (
+  kid: string,
+  state: 'active' | 'previous',
+  byte: number,
+  overrides: Partial<KeyFixture> = {}
+): KeyFixture => ({
+  kid,
+  state,
+  keyBase64url: Buffer.alloc(32, byte).toString('base64url'),
+  notBefore: '2023-01-01T00:00:00Z',
+  verifyUntil: '2030-01-01T00:00:00Z',
+  ...overrides
+})
+
+const createKeyringJson = (
+  activeKid = 'active-1',
+  activeByte = 0x11,
+  previous?: KeyFixture
+): string =>
+  JSON.stringify({
+    version: '1',
+    activeKid,
+    keys: [createKey(activeKid, 'active', activeByte), ...(previous ? [previous] : [])]
+  })
+
+const createTemporaryDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), 'mcp-service-hmac-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+const writeKeyring = async (directory: string, json: string, name = 'keyring.json'): Promise<string> => {
+  const path = join(directory, name)
+  await writeFile(path, json, { mode: 0o400 })
+  await chmod(path, 0o400)
+  return path
+}
+
+const replaceKeyring = async (path: string, json: string): Promise<void> => {
+  const candidatePath = `${path}.candidate`
+  await writeFile(candidatePath, json, { mode: 0o400 })
+  await chmod(candidatePath, 0o400)
+  await rename(candidatePath, path)
+}
+
+const bodyBytes = (body: RequestInit['body']): Buffer => {
+  if (body === undefined || body === null) {
+    return Buffer.alloc(0)
+  }
+  if (typeof body === 'string') {
+    return Buffer.from(body, 'utf8')
+  }
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(body)
+  }
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength)
+  }
+  throw new Error('Receiver was given an unsupported body type')
+}
+
+const verifyCapturedRequest = (
+  request: CapturedRequest,
+  keys: ReadonlyMap<string, Buffer>
+): boolean => {
+  const kid = request.headers.get('X-MSQ-Key-Id')
+  const timestamp = request.headers.get('X-MSQ-Timestamp')
+  const nonce = request.headers.get('X-MSQ-Nonce')
+  const suppliedBodyHash = request.headers.get('X-MSQ-Body-SHA256')
+  const suppliedSignature = request.headers.get('X-MSQ-Signature')
+  if (!kid || !timestamp || !nonce || !suppliedBodyHash || !suppliedSignature) {
+    return false
+  }
+
+  const key = keys.get(kid)
+  if (!key) {
+    return false
+  }
+  const computedBodyHash = createHash('sha256').update(bodyBytes(request.body)).digest('hex')
+  if (computedBodyHash !== suppliedBodyHash) {
+    return false
+  }
+
+  const signingString = [
+    'v1',
+    request.method,
+    `${request.url.pathname}${request.url.search}`,
+    timestamp,
+    nonce,
+    suppliedBodyHash
+  ].join('\n')
+  const computedSignature = createHmac('sha256', key).update(signingString, 'utf8').digest('base64url')
+  return computedSignature === suppliedSignature
+}
+
+const cloneCapturedRequest = (
+  request: CapturedRequest,
+  overrides: Partial<Omit<CapturedRequest, 'headers'>> & { headers?: RequestInit['headers'] } = {}
+): CapturedRequest => ({
+  ...request,
+  ...overrides,
+  headers: new Headers(overrides.headers ?? request.headers)
+})
+
+const createCapturingFetch = (): { fetch: FetchLike; requests: CapturedRequest[] } => {
+  const requests: CapturedRequest[] = []
+  const fetch: FetchLike = async (url, init) => {
+    requests.push({
+      url: new URL(url.toString()),
+      method: init?.method ?? 'GET',
+      headers: new Headers(init?.headers),
+      body: init?.body,
+      redirect: init?.redirect
+    })
+    return new Response(null, { status: 204 })
+  }
+  return { fetch, requests }
+}
+
+const createProvider = async ({
+  keyringJson = createKeyringJson(),
+  nonceSource = () => Uint8Array.from({ length: 16 }, (_, index) => index),
+  fetch
+}: {
+  keyringJson?: string
+  nonceSource?: () => Uint8Array
+  fetch: FetchLike
+}): Promise<{ provider: ServiceHmacProvider; keyFilePath: string }> => {
+  const directory = await createTemporaryDirectory()
+  const keyFilePath = await writeKeyring(directory, keyringJson)
+  const provider = new ServiceHmacProvider({
+    keyFilePath,
+    clock: () => FIXED_UNIX_SECONDS,
+    nonceSource,
+    fetch
+  })
+  providers.push(provider)
+  await provider.init()
+  return { provider, keyFilePath }
+}
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.stop()))
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('service-HMAC keyring contract', () => {
+  test('parses the closed active/previous keyring and preserves previous as verify-only metadata', () => {
+    const previous = createKey('previous-1', 'previous', 0x22)
+    const parsed = parseSymmetricKeyring(createKeyringJson('active-1', 0x11, previous))
+
+    expect(parsed).toEqual({
+      version: '1',
+      activeKid: 'active-1',
+      keys: [
+        expect.objectContaining({ kid: 'active-1', state: 'active', key: ACTIVE_KEY }),
+        expect.objectContaining({ kid: 'previous-1', state: 'previous', key: Buffer.alloc(32, 0x22) })
+      ]
+    })
+  })
+
+  test.each([
+    ['unknown top-level property', { version: '1', activeKid: 'active-1', keys: [createKey('active-1', 'active', 0x11)], extra: true }],
+    ['missing active key', { version: '1', activeKid: 'previous-1', keys: [createKey('previous-1', 'previous', 0x11)] }],
+    ['duplicate kids', { version: '1', activeKid: 'duplicate', keys: [createKey('duplicate', 'active', 0x11), createKey('duplicate', 'previous', 0x22)] }],
+    ['mismatched activeKid', { version: '1', activeKid: 'other', keys: [createKey('active-1', 'active', 0x11)] }],
+    ['padded base64url', { version: '1', activeKid: 'active-1', keys: [createKey('active-1', 'active', 0x11, { keyBase64url: `${ACTIVE_KEY.toString('base64url')}=` })] }],
+    ['wrong decoded length', { version: '1', activeKid: 'active-1', keys: [createKey('active-1', 'active', 0x11, { keyBase64url: Buffer.alloc(31, 0x11).toString('base64url') })] }],
+    ['unordered window', { version: '1', activeKid: 'active-1', keys: [createKey('active-1', 'active', 0x11, { notBefore: '2030-01-01T00:00:00Z', verifyUntil: '2029-01-01T00:00:00Z' })] }],
+    ['invalid calendar date', { version: '1', activeKid: 'active-1', keys: [createKey('active-1', 'active', 0x11, { notBefore: '2023-02-30T00:00:00Z' })] }]
+  ])('rejects %s', (_name, keyring) => {
+    expect(() => parseSymmetricKeyring(JSON.stringify(keyring))).toThrow()
+  })
+
+  test('loads only absolute regular non-symlink files with mode 0400 or 0440', async () => {
+    const directory = await createTemporaryDirectory()
+    const keyFilePath = await writeKeyring(directory, createKeyringJson())
+    await expect(loadSymmetricKeyringFile(keyFilePath)).resolves.toMatchObject({ activeKid: 'active-1' })
+
+    await chmod(keyFilePath, 0o440)
+    await expect(loadSymmetricKeyringFile(keyFilePath)).resolves.toMatchObject({ activeKid: 'active-1' })
+
+    await chmod(keyFilePath, 0o600)
+    await expect(loadSymmetricKeyringFile(keyFilePath)).rejects.toThrow('mode must be 0400 or 0440')
+    await expect(loadSymmetricKeyringFile('relative-keyring.json')).rejects.toThrow('must be absolute')
+
+    const targetPath = await writeKeyring(directory, createKeyringJson(), 'target.json')
+    const linkPath = join(directory, 'link.json')
+    await symlink(targetPath, linkPath)
+    await expect(loadSymmetricKeyringFile(linkPath)).rejects.toThrow('could not be opened securely')
+  })
+})
+
+describe('service-HMAC signed fetch contract', () => {
+  test.each([
+    {
+      method: 'POST',
+      path: '?sessionId=abc',
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1 }),
+      nonce: Uint8Array.from({ length: 16 }, (_, index) => index),
+      expectedHash: 'fe46396dd3e614a8ae91a84e50c35548d8a5d7940d74dd33dc20c86f042329bc',
+      expectedNonce: 'AAECAwQFBgcICQoLDA0ODw',
+      expectedSignature: '4xSjVM1VIKlOm0IM5YPTIZavNnz2wToJ4YNtOGXHpD0'
+    },
+    {
+      method: 'GET',
+      path: '',
+      body: undefined,
+      nonce: Buffer.alloc(16, 0x22),
+      expectedHash: EMPTY_SHA256,
+      expectedNonce: 'IiIiIiIiIiIiIiIiIiIiIg',
+      expectedSignature: 'WKFCwkhBJq-om6ZKRAWD0PRXRqQOdi9OQf4HwC8j7vA'
+    },
+    {
+      method: 'DELETE',
+      path: '?sessionId=gone',
+      body: undefined,
+      nonce: Buffer.alloc(16, 0x33),
+      expectedHash: EMPTY_SHA256,
+      expectedNonce: 'MzMzMzMzMzMzMzMzMzMzMw',
+      expectedSignature: 'uwMe6DyGfQPj6svlu1iyBDXSdmMyhyVFqH0ln3jzWtc'
+    }
+  ])('matches the independent $method golden vector', async ({ method, path, body, nonce, expectedHash, expectedNonce, expectedSignature }) => {
+    const capture = createCapturingFetch()
+    const { provider } = await createProvider({ fetch: capture.fetch, nonceSource: () => nonce })
+
+    await provider.createSignedFetch()(`${COMMS_MANAGEMENT_MCP_URL}${path}`, {
+      method,
+      headers: { Accept: 'application/json, text/event-stream', 'Mcp-Session-Id': 'sdk-session' },
+      body
+    })
+
+    expect(capture.requests).toHaveLength(1)
+    const request = capture.requests[0]
+    expect(request.redirect).toBe('error')
+    expect(request.method).toBe(method)
+    expect(request.headers.get('accept')).toBe('application/json, text/event-stream')
+    expect(request.headers.get('mcp-session-id')).toBe('sdk-session')
+    expect(request.headers.get('X-MSQ-Key-Id')).toBe('active-1')
+    expect(request.headers.get('X-MSQ-Timestamp')).toBe(String(FIXED_UNIX_SECONDS))
+    expect(request.headers.get('X-MSQ-Nonce')).toBe(expectedNonce)
+    expect(request.headers.get('X-MSQ-Body-SHA256')).toBe(expectedHash)
+    expect(request.headers.get('X-MSQ-Signature')).toBe(expectedSignature)
+    expect(bodyBytes(request.body)).toEqual(Buffer.from(body ?? '', 'utf8'))
+    expect(verifyCapturedRequest(request, new Map([['active-1', ACTIVE_KEY]]))).toBe(true)
+  })
+
+  test('binds method, pathname, query, body, timestamp, nonce, key ID, and signature', async () => {
+    const capture = createCapturingFetch()
+    const { provider } = await createProvider({ fetch: capture.fetch })
+    await provider.createSignedFetch()(`${COMMS_MANAGEMENT_MCP_URL}?sessionId=abc`, {
+      method: 'POST',
+      body: 'body'
+    })
+    const request = capture.requests[0]
+    const keys = new Map([['active-1', ACTIVE_KEY]])
+    expect(verifyCapturedRequest(request, keys)).toBe(true)
+
+    const mutations: CapturedRequest[] = [
+      cloneCapturedRequest(request, { method: 'DELETE' }),
+      cloneCapturedRequest(request, { url: new URL('https://comms-management:8080/internal/other?sessionId=abc') }),
+      cloneCapturedRequest(request, { url: new URL(`${COMMS_MANAGEMENT_MCP_URL}?sessionId=changed`) }),
+      cloneCapturedRequest(request, { body: 'changed-body' })
+    ]
+    for (const [header, value] of [
+      ['X-MSQ-Timestamp', String(FIXED_UNIX_SECONDS + 1)],
+      ['X-MSQ-Nonce', Buffer.alloc(16, 0x77).toString('base64url')],
+      ['X-MSQ-Key-Id', 'unknown'],
+      ['X-MSQ-Signature', 'invalid']
+    ]) {
+      const headers = new Headers(request.headers)
+      headers.set(header, value)
+      mutations.push(cloneCapturedRequest(request, { headers }))
+    }
+
+    for (const mutation of mutations) {
+      expect(verifyCapturedRequest(mutation, keys)).toBe(false)
+    }
+  })
+
+  test('creates a fresh nonce and signature for every transport attempt', async () => {
+    let nonceCounter = 0
+    const capture = createCapturingFetch()
+    const { provider } = await createProvider({
+      fetch: capture.fetch,
+      nonceSource: () => Buffer.alloc(16, ++nonceCounter)
+    })
+    const signedFetch = provider.createSignedFetch()
+
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'POST', body: 'same-body' })
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'POST', body: 'same-body' })
+
+    expect(capture.requests).toHaveLength(2)
+    expect(capture.requests[0].headers.get('X-MSQ-Nonce')).not.toBe(capture.requests[1].headers.get('X-MSQ-Nonce'))
+    expect(capture.requests[0].headers.get('X-MSQ-Signature')).not.toBe(capture.requests[1].headers.get('X-MSQ-Signature'))
+  })
+
+  test('rejects reserved caller headers, redirects, URL drift, methods, and unsupported bodies before disclosure', async () => {
+    let nonceCalls = 0
+    let underlyingCalls = 0
+    const provider = new ServiceHmacProvider({
+      clock: () => FIXED_UNIX_SECONDS,
+      nonceSource: () => {
+        nonceCalls += 1
+        return Buffer.alloc(16)
+      },
+      fetch: async () => {
+        underlyingCalls += 1
+        return new Response(null, { status: 204 })
+      }
+    })
+    providers.push(provider)
+    const signedFetch = provider.createSignedFetch()
+
+    const invalidUrls = [
+      'https://comms-management/internal/mcp',
+      'https://comms-management:8081/internal/mcp',
+      'http://comms-management:8080/internal/mcp',
+      'https://other:8080/internal/mcp',
+      'https://comms-management:8080/internal/other',
+      'https://comms-management:8080/internal/mcp#fragment'
+    ]
+    for (const url of invalidUrls) {
+      await expect(signedFetch(url, { method: 'GET' })).rejects.toThrow('out-of-profile request URL')
+    }
+    await expect(signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'PUT' })).rejects.toThrow('unsupported HTTP method')
+    await expect(signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'post' })).rejects.toThrow('unsupported HTTP method')
+    await expect(signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'POST', body: new FormData() })).rejects.toThrow('body type')
+    await expect(signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'POST', body: new ReadableStream() })).rejects.toThrow('body type')
+    await expect(signedFetch(COMMS_MANAGEMENT_MCP_URL, {
+      method: 'GET',
+      headers: { 'x-MsQ-sIgNaTuRe': 'static' }
+    })).rejects.toThrow('caller-supplied authentication header')
+
+    expect(nonceCalls).toBe(0)
+    expect(underlyingCalls).toBe(0)
+  })
+
+  test('accepts UTF-8 strings and byte arrays without changing transmitted bytes', async () => {
+    const capture = createCapturingFetch()
+    const { provider } = await createProvider({ fetch: capture.fetch })
+    const signedFetch = provider.createSignedFetch()
+    const utf8 = 'snowman ☃'
+    const bytes = Uint8Array.from([0, 1, 2, 127, 128, 255])
+
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'POST', body: utf8 })
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'POST', body: bytes })
+
+    expect(bodyBytes(capture.requests[0].body)).toEqual(Buffer.from(utf8, 'utf8'))
+    expect(bodyBytes(capture.requests[1].body)).toEqual(Buffer.from(bytes))
+    expect(capture.requests[0].headers.get('X-MSQ-Body-SHA256')).toBe(
+      createHash('sha256').update(Buffer.from(utf8, 'utf8')).digest('hex')
+    )
+    expect(capture.requests[1].headers.get('X-MSQ-Body-SHA256')).toBe(
+      createHash('sha256').update(bytes).digest('hex')
+    )
+  })
+})
+
+describe('service-HMAC readiness and reload', () => {
+  test('missing and invalid initial keyrings are unavailable without invoking fetch', async () => {
+    let underlyingCalls = 0
+    const missingProvider = new ServiceHmacProvider({
+      clock: () => FIXED_UNIX_SECONDS,
+      fetch: async () => {
+        underlyingCalls += 1
+        return new Response(null, { status: 204 })
+      }
+    })
+    providers.push(missingProvider)
+    await missingProvider.init()
+    expect(missingProvider.isReady()).toBe(false)
+    expect(() => missingProvider.assertReady()).toThrow(McpServiceHmacUnavailableError)
+    await expect(missingProvider.createSignedFetch()(COMMS_MANAGEMENT_MCP_URL, { method: 'GET' })).rejects.toThrow(
+      McpServiceHmacUnavailableError
+    )
+
+    const directory = await createTemporaryDirectory()
+    const invalidPath = await writeKeyring(directory, '{"version":"1"}')
+    const invalidProvider = new ServiceHmacProvider({ keyFilePath: invalidPath, clock: () => FIXED_UNIX_SECONDS })
+    providers.push(invalidProvider)
+    await invalidProvider.init()
+    expect(invalidProvider.isReady()).toBe(false)
+    expect(() => invalidProvider.assertReady()).toThrow(McpServiceHmacUnavailableError)
+    expect(underlyingCalls).toBe(0)
+  })
+
+  test('unavailable readiness serializes through the typed MCP error contract', () => {
+    expect(toMcpErrorResponse(new McpServiceHmacUnavailableError('comms_management'))).toEqual({
+      statusCode: 503,
+      body: {
+        success: false,
+        error: 'Service-HMAC profile comms_management is unavailable.',
+        code: 'service_unavailable',
+        serviceHmacProfile: 'comms_management'
+      }
+    })
+  })
+
+  test('valid reload atomically changes the active signing key and never selects previous', async () => {
+    const capture = createCapturingFetch()
+    const previous = createKey('previous-1', 'previous', 0x44)
+    const { provider, keyFilePath } = await createProvider({
+      fetch: capture.fetch,
+      keyringJson: createKeyringJson('active-1', 0x11, previous)
+    })
+    const signedFetch = provider.createSignedFetch()
+
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'GET' })
+    expect(capture.requests[0].headers.get('X-MSQ-Key-Id')).toBe('active-1')
+
+    await replaceKeyring(keyFilePath, createKeyringJson('active-2', 0x22, createKey('active-1', 'previous', 0x11)))
+    await provider.reload()
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'GET' })
+    expect(capture.requests[1].headers.get('X-MSQ-Key-Id')).toBe('active-2')
+    expect(capture.requests.every((request) => request.headers.get('X-MSQ-Key-Id') !== 'previous-1')).toBe(true)
+  })
+
+  test('invalid reload retains the prior candidate for recovery but disables signing until a valid reload', async () => {
+    const capture = createCapturingFetch()
+    const { provider, keyFilePath } = await createProvider({ fetch: capture.fetch })
+    const signedFetch = provider.createSignedFetch()
+
+    await replaceKeyring(keyFilePath, '{"version":"1"}')
+    await provider.reload()
+    expect(provider.isReady()).toBe(false)
+    await expect(signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'GET' })).rejects.toThrow(McpServiceHmacUnavailableError)
+    expect(capture.requests).toHaveLength(0)
+
+    await replaceKeyring(keyFilePath, createKeyringJson('active-2', 0x22))
+    await provider.reload()
+    expect(provider.isReady()).toBe(true)
+    await signedFetch(COMMS_MANAGEMENT_MCP_URL, { method: 'GET' })
+    expect(capture.requests[0].headers.get('X-MSQ-Key-Id')).toBe('active-2')
+  })
+
+  test('SIGHUP reloads the candidate and stop removes the owned listener', async () => {
+    const initialListeners = process.listenerCount('SIGHUP')
+    const capture = createCapturingFetch()
+    const { provider, keyFilePath } = await createProvider({ fetch: capture.fetch })
+    expect(process.listenerCount('SIGHUP')).toBe(initialListeners + 1)
+
+    await replaceKeyring(keyFilePath, createKeyringJson('active-2', 0x22))
+    process.emit('SIGHUP')
+
+    const deadline = Date.now() + 2000
+    while (Date.now() < deadline) {
+      await provider.createSignedFetch()(COMMS_MANAGEMENT_MCP_URL, { method: 'GET' })
+      if (capture.requests.at(-1)?.headers.get('X-MSQ-Key-Id') === 'active-2') {
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(capture.requests.at(-1)?.headers.get('X-MSQ-Key-Id')).toBe('active-2')
+
+    await provider.stop()
+    expect(process.listenerCount('SIGHUP')).toBe(initialListeners)
+  })
+})
+
+describe('service-HMAC MCP service isolation', () => {
+  const createMcpService = (serviceHmacProvider?: ServiceHmacProvider): MCPService =>
+    new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: {
+        getUserServerSecrets: jest.fn().mockResolvedValue({})
+      } as never,
+      userServerInstalls: {} as never,
+      serviceHmacProvider
+    })
+
+  const serviceHmacServer = {
+    name: 'comms-management',
+    source: 'platform' as const,
+    transportType: 'streamable_http' as const,
+    authMode: 'service_hmac' as const,
+    serviceHmacProfile: 'comms_management' as const,
+    url: COMMS_MANAGEMENT_MCP_URL,
+    status: 'disconnected' as const,
+    enabled: true
+  }
+
+  test('selects signed fetch only for the validated service profile', async () => {
+    const capture = createCapturingFetch()
+    const { provider } = await createProvider({ fetch: capture.fetch })
+    const signedFetchSpy = jest.spyOn(provider, 'createSignedFetch')
+    const service = createMcpService(provider)
+    const buildTransportOptions = Reflect.get(service, 'buildTransportOptions').bind(service)
+
+    const signedOptions = await buildTransportOptions(serviceHmacServer, 'runtime-user')
+    expect(signedOptions.fetch).toBeInstanceOf(Function)
+    expect(signedFetchSpy).toHaveBeenCalledTimes(1)
+
+    const noneOptions = await buildTransportOptions({
+      name: 'ordinary-http',
+      source: 'platform',
+      transportType: 'streamable_http',
+      authMode: 'none',
+      url: 'https://example.com/mcp',
+      headers: { 'X-Existing': 'preserved' },
+      status: 'disconnected',
+      enabled: true
+    })
+    const oauthOptions = await buildTransportOptions({
+      name: 'ordinary-oauth',
+      source: 'external',
+      transportType: 'streamable_http',
+      authMode: 'oauth2',
+      url: 'https://example.com/mcp',
+      status: 'disconnected',
+      enabled: true
+    })
+    const stdioOptions = await buildTransportOptions({
+      name: 'ordinary-stdio',
+      source: 'platform',
+      transportType: 'stdio',
+      authMode: 'none',
+      command: 'node',
+      args: ['server.js'],
+      env: {},
+      status: 'disconnected',
+      enabled: true
+    })
+
+    expect(noneOptions.fetch).toBeUndefined()
+    expect(oauthOptions.fetch).toBeUndefined()
+    expect(stdioOptions).toEqual({})
+    expect(signedFetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('missing signing readiness blocks only service-HMAC transport options', async () => {
+    const service = createMcpService()
+    const buildTransportOptions = Reflect.get(service, 'buildTransportOptions').bind(service)
+
+    await expect(buildTransportOptions(serviceHmacServer, 'runtime-user')).rejects.toThrow(
+      McpServiceHmacUnavailableError
+    )
+    await expect(buildTransportOptions({
+      name: 'ordinary-http',
+      source: 'platform',
+      transportType: 'streamable_http',
+      authMode: 'none',
+      url: 'https://example.com/mcp',
+      status: 'disconnected',
+      enabled: true
+    })).resolves.toEqual({})
+  })
+
+  test('invalid add configuration fails before database access or network work', async () => {
+    const service = createMcpService()
+    const findOne = jest.fn()
+    const insert = jest.fn()
+    Reflect.set(service, 'mcpDBClient', { findOne, insert })
+
+    await expect(service.addServer({
+      name: 'invalid-comms',
+      source: 'external',
+      transportType: 'streamable_http',
+      authMode: 'service_hmac',
+      serviceHmacProfile: 'comms_management',
+      url: COMMS_MANAGEMENT_MCP_URL,
+      username: 'alice'
+    })).rejects.toThrow('service_hmac requires source platform')
+    expect(findOne).not.toHaveBeenCalled()
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  test('partial updates validate merged state before database write or network work', async () => {
+    const service = createMcpService()
+    const update = jest.fn()
+    Reflect.set(service, 'mcpDBClient', {
+      findOne: jest.fn().mockResolvedValue(serviceHmacServer),
+      update
+    })
+
+    await expect(service.updateServer('comms-management', {
+      url: 'https://comms-management:8080/alternate'
+    })).rejects.toThrow(`service_hmac requires url ${COMMS_MANAGEMENT_MCP_URL}`)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  test('invalid persisted state is rejected before secret migration or outbound work', async () => {
+    const getSecret = jest.fn()
+    const service = new MCPService({
+      mongoParams: { host: 'localhost:27017', db: 'test', user: 'user', pass: 'pass' },
+      secretsService: { getSecret } as never,
+      userServerInstalls: {} as never
+    })
+    const normalizeServerRecord = Reflect.get(service, 'normalizeServerRecord').bind(service)
+
+    await expect(normalizeServerRecord({
+      ...serviceHmacServer,
+      serviceHmacProfile: undefined
+    })).rejects.toThrow('service_hmac requires serviceHmacProfile comms_management')
+    expect(getSecret).not.toHaveBeenCalled()
+  })
+})

--- a/test/mcp-streamable-http.integration.spec.ts
+++ b/test/mcp-streamable-http.integration.spec.ts
@@ -1,14 +1,22 @@
-import { createServer, type ServerResponse } from 'node:http'
+import { createServer, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { randomUUID } from 'node:crypto'
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { z } from 'zod'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import type { EventStore } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { CallToolResultSchema, ListToolsResultSchema, TextContentSchema, ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
+import {
+  COMMS_MANAGEMENT_MCP_URL,
+  ServiceHmacProvider
+} from '../src/services/serviceHmac'
 
 const waitFor = async (condition: () => boolean, timeoutMs = 4000, intervalMs = 50) => {
   const start = Date.now()
@@ -19,6 +27,57 @@ const waitFor = async (condition: () => boolean, timeoutMs = 4000, intervalMs = 
     await new Promise(resolve => setTimeout(resolve, intervalMs))
   }
   throw new Error('Timed out waiting for condition')
+}
+
+const readRequestBody = async (request: IncomingMessage): Promise<Buffer> => {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+const getSingleHeader = (headers: IncomingHttpHeaders, name: string): string | undefined => {
+  const value = headers[name.toLowerCase()]
+  return Array.isArray(value) ? value[0] : value
+}
+
+const verifyReceivedServiceHmacRequest = ({
+  method,
+  pathnameAndQuery,
+  headers,
+  body,
+  key,
+  expectedTimestamp
+}: {
+  method: string
+  pathnameAndQuery: string
+  headers: IncomingHttpHeaders
+  body: Buffer
+  key: Buffer
+  expectedTimestamp: number
+}): boolean => {
+  const kid = getSingleHeader(headers, 'x-msq-key-id')
+  const timestamp = getSingleHeader(headers, 'x-msq-timestamp')
+  const nonce = getSingleHeader(headers, 'x-msq-nonce')
+  const bodyHash = getSingleHeader(headers, 'x-msq-body-sha256')
+  const signature = getSingleHeader(headers, 'x-msq-signature')
+  if (!kid || !timestamp || !nonce || !bodyHash || !signature) {
+    return false
+  }
+  if (kid !== 'integration-active' || timestamp !== String(expectedTimestamp)) {
+    return false
+  }
+  const nonceBytes = Buffer.from(nonce, 'base64url')
+  if (nonceBytes.length !== 16 || nonceBytes.toString('base64url') !== nonce) {
+    return false
+  }
+  const computedBodyHash = createHash('sha256').update(body).digest('hex')
+  if (computedBodyHash !== bodyHash) {
+    return false
+  }
+  const canonical = ['v1', method, pathnameAndQuery, timestamp, nonce, bodyHash].join('\n')
+  return createHmac('sha256', key).update(canonical, 'utf8').digest('base64url') === signature
 }
 
 describe('Streamable HTTP integration', () => {
@@ -186,5 +245,143 @@ describe('Streamable HTTP integration', () => {
     await client.close()
     await mcpServer.close()
     await new Promise<void>(resolve => httpServer.close(() => resolve()))
+  })
+
+  test('official SDK POST, GET, and DELETE requests are signed over the exact received bytes', async () => {
+    const fixedUnixSeconds = 1_700_000_000
+    const hmacKey = Buffer.alloc(32, 0x5a)
+    let nonceCounter = 0
+    const verifiedRequests: Array<{ method: string; url: string; body: Buffer; nonce: string }> = []
+    let receiverRejectedRequest = false
+
+    const serverTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() })
+    const mcpServer = new McpServer(
+      { name: 'signed-streamable-http', version: '1.0.0' },
+      { capabilities: { tools: {} } }
+    )
+    mcpServer.registerTool(
+      'signed-echo',
+      { description: 'Echo through the signed transport', inputSchema: { text: z.string() } },
+      async ({ text }) => ({ content: [{ type: 'text', text }] })
+    )
+    await mcpServer.connect(serverTransport)
+
+    const httpServer = createServer((request, response) => {
+      void (async () => {
+        const body = await readRequestBody(request)
+        const method = request.method ?? ''
+        const pathnameAndQuery = request.url ?? ''
+        const verified = verifyReceivedServiceHmacRequest({
+          method,
+          pathnameAndQuery,
+          headers: request.headers,
+          body,
+          key: hmacKey,
+          expectedTimestamp: fixedUnixSeconds
+        })
+        if (!verified || new URL(pathnameAndQuery, 'https://receiver.invalid').pathname !== '/internal/mcp') {
+          receiverRejectedRequest = true
+          response.statusCode = 401
+          response.end()
+          return
+        }
+        verifiedRequests.push({
+          method,
+          url: pathnameAndQuery,
+          body,
+          nonce: getSingleHeader(request.headers, 'x-msq-nonce') ?? ''
+        })
+
+        const parsedBody = body.length > 0 ? JSON.parse(body.toString('utf8')) : undefined
+        await serverTransport.handleRequest(request, response, parsedBody)
+      })().catch(() => {
+        if (!response.headersSent) {
+          response.statusCode = 500
+          response.end()
+        }
+      })
+    })
+
+    let port: number
+    try {
+      port = await new Promise<number>((resolve, reject) => {
+        httpServer.once('error', reject)
+        httpServer.listen(0, '127.0.0.1', () => resolve((httpServer.address() as AddressInfo).port))
+      })
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException
+      await mcpServer.close()
+      if (err.code === 'EPERM') {
+        return
+      }
+      throw error
+    }
+
+    const directory = await mkdtemp(join(tmpdir(), 'mcp-sdk-hmac-integration-'))
+    const keyFilePath = join(directory, 'keyring.json')
+    await writeFile(
+      keyFilePath,
+      JSON.stringify({
+        version: '1',
+        activeKid: 'integration-active',
+        keys: [
+          {
+            kid: 'integration-active',
+            state: 'active',
+            keyBase64url: hmacKey.toString('base64url'),
+            notBefore: '2023-01-01T00:00:00Z',
+            verifyUntil: '2030-01-01T00:00:00Z'
+          }
+        ]
+      }),
+      { mode: 0o400 }
+    )
+    await chmod(keyFilePath, 0o400)
+
+    const bridgeFetch: FetchLike = async (input, init) => {
+      const outboundUrl = new URL(input.toString())
+      return fetch(`http://127.0.0.1:${port}${outboundUrl.pathname}${outboundUrl.search}`, init)
+    }
+    const provider = new ServiceHmacProvider({
+      keyFilePath,
+      clock: () => fixedUnixSeconds,
+      nonceSource: () => Buffer.alloc(16, ++nonceCounter),
+      fetch: bridgeFetch
+    })
+    const client = new Client(
+      { name: 'signed-integration-client', version: '1.0.0' },
+      { capabilities: { tools: {} } }
+    )
+    const clientTransport = new StreamableHTTPClientTransport(new URL(COMMS_MANAGEMENT_MCP_URL), {
+      fetch: provider.createSignedFetch()
+    })
+
+    try {
+      await provider.init()
+      await client.connect(clientTransport)
+      const tools = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+      expect(tools.tools.some((tool) => tool.name === 'signed-echo')).toBe(true)
+
+      const result = await client.callTool({ name: 'signed-echo', arguments: { text: 'signed-body' } })
+      expect(result.content).toEqual([{ type: 'text', text: 'signed-body' }])
+
+      await waitFor(() => verifiedRequests.some(({ method }) => method === 'GET'), 5000)
+      await clientTransport.terminateSession()
+
+      expect(receiverRejectedRequest).toBe(false)
+      expect(new Set(verifiedRequests.map(({ method }) => method))).toEqual(new Set(['POST', 'GET', 'DELETE']))
+      expect(new Set(verifiedRequests.map(({ nonce }) => nonce).filter(Boolean)).size).toBe(verifiedRequests.length)
+      expect(
+        verifiedRequests
+          .filter(({ method }) => method === 'POST')
+          .every(({ body }) => createHash('sha256').update(body).digest('hex').length === 64)
+      ).toBe(true)
+    } finally {
+      await client.close().catch(() => {})
+      await provider.stop()
+      await mcpServer.close().catch(() => {})
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 })

--- a/test/mcp-transport.spec.ts
+++ b/test/mcp-transport.spec.ts
@@ -1,6 +1,14 @@
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { assertTransportConfigCompatible, buildServerKey, createTransport, MCPServer } from '../src/services/mcp'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import {
+  assertTransportConfigCompatible,
+  buildServerKey,
+  createSseTransport,
+  createTransport,
+  MCPServer
+} from '../src/services/mcp'
 
 describe('MCP transport utilities', () => {
   test('buildServerKey is stable across transport changes', () => {
@@ -50,6 +58,101 @@ describe('MCP transport utilities', () => {
 
     const transport = createTransport(httpServer)
     expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
+  })
+
+  test('createTransport passes the consumer fetch to the official Streamable HTTP transport', () => {
+    const customFetch: FetchLike = async () => new Response(null, { status: 204 })
+    const transport = createTransport(
+      {
+        name: 'signed-streamable-http',
+        transportType: 'streamable_http',
+        url: 'https://example.com/mcp',
+        status: 'disconnected',
+        enabled: true
+      },
+      { fetch: customFetch }
+    )
+
+    expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
+    expect(Reflect.get(transport, '_fetch')).toBe(customFetch)
+  })
+
+  test('createSseTransport passes the same consumer fetch to the official SSE transport', () => {
+    const customFetch: FetchLike = async () => new Response(null, { status: 204 })
+    const transport = createSseTransport(
+      { transportType: 'streamable_http', url: 'https://example.com/mcp' },
+      { fetch: customFetch }
+    )
+
+    expect(transport).toBeInstanceOf(SSEClientTransport)
+    expect(Reflect.get(transport, '_fetch')).toBe(customFetch)
+  })
+
+  test('official SSE runtime uses the consumer fetch for its GET stream and POST messages', async () => {
+    const methods: string[] = []
+    let closeEventStream = (): void => {}
+    const customFetch: FetchLike = async (_url, init) => {
+      const method = init?.method ?? 'GET'
+      methods.push(method)
+      if (method === 'POST') {
+        return new Response(null, { status: 202 })
+      }
+
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          closeEventStream = () => controller.close()
+          controller.enqueue(
+            new TextEncoder().encode('event: endpoint\ndata: https://example.com/mcp?session=legacy\n\n')
+          )
+        }
+      })
+      return new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' }
+      })
+    }
+    const transport = createSseTransport(
+      { transportType: 'streamable_http', url: 'https://example.com/mcp' },
+      { fetch: customFetch }
+    )
+    if (!(transport instanceof SSEClientTransport)) {
+      throw new Error('Expected the SSE transport factory to return SSEClientTransport')
+    }
+
+    try {
+      await transport.start()
+      await transport.send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+      expect(methods).toEqual(['GET', 'POST'])
+    } finally {
+      await transport.close()
+      closeEventStream()
+    }
+  })
+
+  test('custom fetch remains absent from default HTTP and stdio transports', () => {
+    const customFetch: FetchLike = async () => new Response(null, { status: 204 })
+    const defaultHttpTransport = createTransport({
+      name: 'default-http',
+      transportType: 'streamable_http',
+      url: 'https://example.com/mcp',
+      status: 'disconnected',
+      enabled: true
+    })
+    const stdioTransport = createTransport(
+      {
+        name: 'default-stdio',
+        transportType: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+        env: {},
+        status: 'disconnected',
+        enabled: true
+      },
+      { fetch: customFetch }
+    )
+
+    expect(Reflect.get(defaultHttpTransport, '_fetch')).toBeUndefined()
+    expect(Reflect.get(stdioTransport, '_fetch')).toBeUndefined()
   })
 
   test('streamable_http config rejects stdio-only fields', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,16 +1208,17 @@
     puppeteer-extra-plugin-stealth "^2.11.2"
     superlru "^1.2.0"
 
-"@modelcontextprotocol/sdk@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.13.0.tgz#4ac5f4db34b78ce2da09915821869c618909e692"
-  integrity sha512-P5FZsXU0kY881F6Hbk9GhsYx02/KgWK1DYf7/tyE/1lcFKhDYPQR9iYjhQXJn+Sg6hQleMo3DB7h7+p4wgp2Lw==
+"@modelcontextprotocol/sdk@1.16.0":
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz#39a28a4f775778ec90369ddb5ccfb58a5b9b838f"
+  integrity sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==
   dependencies:
     ajv "^6.12.6"
     content-type "^1.0.5"
     cors "^2.8.5"
     cross-spawn "^7.0.5"
     eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
     express "^5.0.1"
     express-rate-limit "^7.5.0"
     pkce-challenge "^5.0.0"


### PR DESCRIPTION
## Summary

- add the closed `service_hmac` / `comms_management` MCP server profile for the exact internal Comms Management endpoint
- load, validate, and atomically reload the service keyring from `MSQ_COMMS_MCP_HMAC_KEY_FILE`
- inject a profile-scoped signed fetch into the official Streamable HTTP transport and its SSE fallback without changing stdio, unauthenticated HTTP, OAuth, user-session, or external SSRF behavior
- pin `@modelcontextprotocol/sdk` to `1.16.0` and bump the service release version to `1.11.20`
- add credential-free golden, negative, reload, factory, fallback, SSRF/session, and end-to-end transport coverage

## Governing contract

Implements ADR-0044, D-063, REQ-112, and AT-SEC-015.

## SDK research gate

The installed declarations and runtime were inspected before implementation. SDK `1.16.0` is the first selected released V1 version at or above the required floor where both `StreamableHTTPClientTransportOptions` and `SSEClientTransportOptions` accept `fetch?: FetchLike`, and the runtime consistently routes the relevant transport requests through that fetch.

## Verification

- baseline at `a4d72a2cd49ab9e567ebf937fff2615a9b3d6449`: `yarn build` passed; `yarn test --runInBand` passed (10 suites, 189 tests)
- exact SDK bump only: `yarn install`, `yarn build`, and `yarn test --runInBand` passed (10 suites, 189 tests)
- focused modified/new suites passed (4 suites, 121 tests)
- final `yarn build` passed
- final `yarn test --runInBand` passed (11 suites, 243 tests)
- clean tracked-source Docker build passed for local tag `mcp-api:service-hmac-v1.11.20-test`

The repository has no lint script. Jest continues to emit its pre-existing unknown `noEmit` configuration warning, and Docker continues to emit the pre-existing legacy `ENV` format warning.

## Platform connection payload

```json
{
  "name": "<platform-owned-server-name>",
  "source": "platform",
  "transportType": "streamable_http",
  "authMode": "service_hmac",
  "serviceHmacProfile": "comms_management",
  "url": "https://comms-management:8080/internal/mcp"
}
```

The key-file path and all signing material remain process-local and are not part of the persisted or returned server definition.
